### PR TITLE
feat: conditionally display opload message based on 1Password authentication

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,5 @@
 - Use opload to get ask-become-pass variable for "become: true" tasks
 
 - When I ask for a TODO or an Issue or Feature request, always use GitHub issues for this repository to track those
+
+- never copy files manually, only use ansible

--- a/roles/localhost/tasks/zshrc-linux
+++ b/roles/localhost/tasks/zshrc-linux
@@ -77,7 +77,10 @@ if [ -f "$HOME/.env" ]; then
     done
 
     if [ ${#MISSING_VARS[@]} -eq 0 ]; then
-        echo "Use opload to load environment variables from .env"
+        # Check if user is already authenticated to 1Password
+        if ! op whoami >/dev/null 2>&1; then
+            echo "Use opload to load environment variables from .env"
+        fi
     else
         echo "Warning: Missing required variables in .env file:"
         printf '%s\n' "${MISSING_VARS[@]}"


### PR DESCRIPTION
$(cat <<'EOF'
## Summary
This PR implements conditional display of the opload message based on 1Password authentication status, addressing issue #4.

### Changes Made
- ✅ **Conditional Logic**: Added check for 1Password authentication using `op whoami`
- ✅ **User Experience**: Only shows opload message when user is not authenticated
- ✅ **Backward Compatibility**: Maintains all existing functionality

### Implementation Details
The change modifies the shell startup logic in `roles/localhost/tasks/zshrc-linux` to:
1. Check if all required environment variables are referenced in `.env`
2. If they are, check if user is authenticated to 1Password (`op whoami`)
3. Only display the opload message if authentication check fails

### Benefits
- **Cleaner shell startup** - No unnecessary messages for authenticated users
- **Reduced visual noise** - Terminal sessions start cleanly when already logged in
- **Helpful reminders maintained** - Unauthenticated users still see the guidance

### Test Plan
- [x] Syntax validation passes
- [x] Pre-commit hooks pass
- [x] Tested with authenticated 1Password session (no message displayed)
- [x] Logic correctly detects authentication status

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)
EOF
)