### PR TITLE
feat: conditionally display opload message based on 1Password authent…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,3 +3,5 @@
 - Use opload to get ask-become-pass variable for "become: true" tasks
 
 - When I ask for a TODO or an Issue or Feature request, always use GitHub issues for this repository to track those
+
+- never copy files manually, only use ansible

--- a/roles/localhost/tasks/zshrc-linux
+++ b/roles/localhost/tasks/zshrc-linux
@@ -77,7 +77,10 @@ if [ -f "$HOME/.env" ]; then
     done
 
     if [ ${#MISSING_VARS[@]} -eq 0 ]; then
-        echo "Use opload to load environment variables from .env"
+        # Check if user is already authenticated to 1Password
+        if ! op whoami >/dev/null 2>&1; then
+            echo "Use opload to load environment variables from .env"
+        fi
     else
         echo "Warning: Missing required variables in .env file:"
         printf '%s\n' "${MISSING_VARS[@]}"


### PR DESCRIPTION
…ication

Only show the "Use opload to load environment variables from .env" message when the user is not already authenticated to 1Password. This reduces visual noise for authenticated users while maintaining the helpful reminder for unauthenticated users.

Closes #4

🤖 Generated with [Claude Code](https://claude.ai/code)

# Pull Request Template

## Description
Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
