### PR TITLE
fix: improve macOS shell configuration with 1Password integration

### DIFF
--- a/roles/localhost/files/zshrc-mac
+++ b/roles/localhost/files/zshrc-mac
@@ -5,48 +5,66 @@ OMP_THEME_NAME="night-owl.omp.json"
 # OMP_THEME_NAME="jandedobbeleer.omp.json"
 # OMP_THEME_NAME="kushal.omp.json"
 
-# Oh-my-posh theme setup (change OMP_THEME_NAME ^above to switch themes)
-if command -v oh-my-posh >/dev/null 2>&1; then
-    OMP_THEME_CMD=$(oh-my-posh init zsh --config "$HOME/.cache/oh-my-posh/themes/$OMP_THEME_NAME")
+# Initialize Homebrew first
+if [ -f "/opt/homebrew/bin/brew" ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -f "/usr/local/bin/brew" ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
 else
+    echo "Homebrew not found" >&2
+fi
+
+# Now we can safely use brew commands
+BREW_PREFIX="$(brew --prefix)/bin"
+
+# Oh-my-posh theme setup (change OMP_THEME_NAME to switch themes)
+if command -v "${BREW_PREFIX}/oh-my-posh" >/dev/null 2>&1 && command -v "${BREW_PREFIX}/brew" >/dev/null 2>&1; then
+    OMP_THEME_CMD="$(${BREW_PREFIX}/oh-my-posh init zsh --config "$(${BREW_PREFIX}/brew --prefix oh-my-posh)/themes/$OMP_THEME_NAME")"
+else
+    echo "Could not set OMP_THEME_CMD" >&2
     OMP_THEME_CMD=""
 fi
-
-# PATH management for Homebrew
-if [ -d "/opt/homebrew/bin" ] && [[ ":$PATH:" != *":/opt/homebrew/bin:"* ]]; then
-    export PATH="/opt/homebrew/bin:$PATH"
+DOTFILES_ALIAS="alias dotfiles='/usr/bin/git --git-dir="$HOME/.dotfiles/.git/" --work-tree="$HOME"'"
+# Homebrew
+if [ -x "$BREW_PREFIX/brew" ]; then
+    eval "$($BREW_PREFIX/brew shellenv)"
 fi
 
-if [ -d "/opt/homebrew/sbin" ] && [[ ":$PATH:" != *":/opt/homebrew/sbin:"* ]]; then
-    export PATH="/opt/homebrew/sbin:$PATH"
-fi
-
-# Add local bin to PATH if it exists
-if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$PATH:$HOME/.local/bin"
-fi
-
-# Apply oh-my-posh theme if available
+# Setup oh-my-posh theme if defined
 if [ -n "$OMP_THEME_CMD" ]; then
     eval "$OMP_THEME_CMD"
 fi
 
-# Path to Oh My Zsh installation
-export ZSH="$HOME/.oh-my-zsh"
+# Setup dotfiles alias if defined
+if [ -n "$DOTFILES_ALIAS" ]; then
+    eval "$DOTFILES_ALIAS"
+fi
 
-# Python virtual environment configuration
+# Get all environment variables from the .env file
+$(cat ~/.env | ${BREW_PREFIX}/op inject --)
+
+# Set vi mode
+set -o vi
+
+# Python auto env setup
 PYTHON_VENV_NAME=".venv"
 PYTHON_AUTO_VRUN=true
 PYTHON_VENV_NAMES=($PYTHON_VENV_NAME venv)
 
-# Oh My Zsh plugins (Mac-appropriate)
+# Path to your Oh My Zsh installation
+export ZSH="$HOME/.oh-my-zsh"
+
+# Theme and plugins configuration
 plugins=(git gh macos pip poetry python)
 
 # Source Oh My Zsh
 source $ZSH/oh-my-zsh.sh
 
-# Set vi mode
-set -o vi
+# Additional plugin configuration
+source /opt/homebrew/share/zsh-history-substring-search/zsh-history-substring-search.zsh
+
+# Auto Suggestions
+source /opt/homebrew/share/zsh-autosuggestions/zsh-autosuggestions.zsh
 
 # Load additional plugins if installed via Homebrew
 # Syntax highlighting
@@ -69,9 +87,6 @@ if [ -f /opt/homebrew/share/zsh-history-substring-search/zsh-history-substring-s
     source /opt/homebrew/share/zsh-history-substring-search/zsh-history-substring-search.zsh
 fi
 
-# 1Password login and environment variable loading alias
-alias opload='eval $(op signin) && eval $(cat ~/.env | op inject --)'
-
 # Load environment variables from .env file with validation
 REQUIRED_VARS=(GITHUB_TOKEN ANSIBLE_SUDO_PASS)
 if [ -f "$HOME/.env" ]; then
@@ -82,22 +97,5 @@ if [ -f "$HOME/.env" ]; then
         if ! grep -q "$var" "$HOME/.env"; then
             MISSING_VARS+=($var)
         fi
-    done
-
-    if [ ${#MISSING_VARS[@]} -eq 0 ]; then
-        # Check if user is already authenticated to 1Password
-        if ! op whoami >/dev/null 2>&1; then
-            echo "Use opload to load environment variables from .env"
-        fi
-    else
-        echo "Warning: Missing required variables in .env file:"
-        printf '%s\n' "${MISSING_VARS[@]}"
-    fi
-else
-    echo "Warning: .env file not found in $HOME"
-    # Provide instructions to create it using the REQUIRED_VARS array above
-    echo "Please create a .env file in your home directory with the following content:"
-    for var in ${REQUIRED_VARS[@]}; do
-        echo "export $var="
     done
 fi


### PR DESCRIPTION
## Summary
- Initialize Homebrew earlier in shell configuration for proper PATH setup
- Add automatic 1Password environment variable injection using `op inject`
- Streamline oh-my-posh setup with proper brew path handling
- Simplify environment variable validation and remove redundant checks
- Remove manual `opload` alias in favor of automatic injection

## Test plan
- [ ] Test shell initialization on macOS systems
- [ ] Verify 1Password integration works automatically
- [ ] Confirm oh-my-posh themes load correctly
- [ ] Validate environment variables are properly injected

🤖 Generated with [Claude Code](https://claude.ai/code)