### PR TITLE
Prepare ansible config for dotfiles repository retirement

### DIFF
--- a/roles/localhost/files/zshrc-mac
+++ b/roles/localhost/files/zshrc-mac
@@ -24,7 +24,7 @@ else
     echo "Could not set OMP_THEME_CMD" >&2
     OMP_THEME_CMD=""
 fi
-DOTFILES_ALIAS="alias dotfiles='/usr/bin/git --git-dir="$HOME/.dotfiles/.git/" --work-tree="$HOME"'"
+
 # Homebrew
 if [ -x "$BREW_PREFIX/brew" ]; then
     eval "$($BREW_PREFIX/brew shellenv)"
@@ -33,11 +33,6 @@ fi
 # Setup oh-my-posh theme if defined
 if [ -n "$OMP_THEME_CMD" ]; then
     eval "$OMP_THEME_CMD"
-fi
-
-# Setup dotfiles alias if defined
-if [ -n "$DOTFILES_ALIAS" ]; then
-    eval "$DOTFILES_ALIAS"
 fi
 
 # Get all environment variables from the .env file

--- a/roles/localhost/tasks/local-mac.yml
+++ b/roles/localhost/tasks/local-mac.yml
@@ -47,6 +47,14 @@
     state: directory
     mode: '0700'
 
+- name: Create SSH config file with 1Password agent
+  ansible.builtin.copy:
+    content: |
+      Host *
+        IdentityAgent "~/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+    dest: "{{ lookup('env', 'HOME') }}/.ssh/config"
+    mode: '0600'
+
 - name: Create SSH allowed signers file
   ansible.builtin.copy:
     content: "david@davidsnider.org ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIKWm36FodEyxXOXxqhkCj0YLDHkori4Dzmq3hI0PsrX9"
@@ -177,15 +185,6 @@
     path: "{{ lookup('env', 'HOME') }}/.gitignore"
     line: ".dotfiles"
   register: localhost_gitignore_status
-
-- name: Clone the dotfiles repository
-  ansible.builtin.git:
-    repo: https://github.com/davidasnider/dotfiles.git
-    dest: "{{ lookup('env', 'HOME') }}/.dotfiles"
-    version: main # Or specify a branch/tag if needed
-    force: true
-  register: localhost_clone_status
-  notify: Ignore untracked files for dotfiles
 
 - name: Ensure ~/.local/bin directory exists
   ansible.builtin.file:


### PR DESCRIPTION
## Summary

This PR prepares the ansible configuration to be fully self-contained, enabling retirement of the separate dotfiles repository.

### Changes Made

- ✅ **Add SSH config management**: Creates `~/.ssh/config` with 1Password agent integration
- ✅ **Remove dotfiles dependency**: Eliminates dotfiles repository cloning task
- ✅ **Clean up shell config**: Remove dotfiles git alias from zshrc configuration
- ✅ **Self-contained setup**: Ansible now manages all necessary configurations directly

### Migration Status

**What's Already Handled by Ansible:**
- Shell configuration (zshrc with oh-my-posh, plugins)
- Git configuration (user, signing keys, security settings)
- Homebrew packages and applications
- Oh My Zsh installation and setup
- Environment variable validation

**What This PR Adds:**
- SSH configuration with 1Password agent
- Removes external dotfiles repository dependency

### Test Plan

- [x] Ansible playbook runs successfully without dotfiles repository
- [x] SSH configuration is properly created
- [x] Shell environment loads correctly
- [x] All linting passes

### Next Steps

After this PR is merged:
1. Validate the ansible configuration works on all target systems
2. Archive/retire the dotfiles repository
3. Update any documentation referencing the old dotfiles setup

🤖 Generated with [Claude Code](https://claude.ai/code)