### PR TITLE
Refactor Zsh initialization and add mac-workstation-update skill

### DIFF
--- a/.agents/skills/mac-workstation-update/SKILL.md
+++ b/.agents/skills/mac-workstation-update/SKILL.md
@@ -6,6 +6,13 @@ description: Runs the Ansible playbook to update the local macOS workstation con
 1. Validates that the current system is macOS.
 2. Executes the `workstations.yml` playbook using Poetry to ensure all local configurations, tools, and security settings are up to date.
 
+### Prerequisites
+
+- Run this skill from the repository root so relative paths such as `inventory/hosts.yml` and `playbooks/workstations.yml` resolve correctly.
+- Export `ANSIBLE_SUDO_PASS` in your environment before running this skill; the playbook reads it for `ansible_become_pass`.
+- Ensure `poetry` is installed and the project dependencies needed for `ansible-playbook` are available.
+- This skill is intended only for macOS.
+
 // turbo
 ```bash
 if [[ "$(uname)" != "Darwin" ]]; then

--- a/.agents/skills/mac-workstation-update/SKILL.md
+++ b/.agents/skills/mac-workstation-update/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: mac-workstation-update
+description: Runs the Ansible playbook to update the local macOS workstation configuration.
+---
+
+1. Validates that the current system is macOS.
+2. Executes the `workstations.yml` playbook using Poetry to ensure all local configurations, tools, and security settings are up to date.
+
+// turbo
+```bash
+if [[ "$(uname)" != "Darwin" ]]; then
+  echo "❌ This skill is intended only for macOS."
+  exit 1
+fi
+
+echo "🚀 Updating local macOS workstation..."
+poetry run ansible-playbook -i inventory/hosts.yml playbooks/workstations.yml --limit localhost
+echo "✅ Workstation update complete."
+```

--- a/roles/workstation/tasks/local-linux.yml
+++ b/roles/workstation/tasks/local-linux.yml
@@ -363,6 +363,13 @@
     mode: "0644"
   changed_when: false
 
+- name: Copy zshenv file
+  ansible.builtin.copy:
+    src: zshenv-linux
+    dest: "{{ ansible_env.HOME }}/.zshenv"
+    mode: "0644"
+  changed_when: false
+
 - name: Copy zprofile file
   ansible.builtin.copy:
     src: zprofile-linux

--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -364,6 +364,13 @@
     dest: "{{ lookup('env', 'HOME') }}/.zshrc"
     mode: "0644"
 
+- name: Copy zshenv file
+  ansible.builtin.copy:
+    src: zshenv-mac
+    dest: "{{ lookup('env', 'HOME') }}/.zshenv"
+    mode: "0644"
+  changed_when: false
+
 - name: Copy zprofile file
   ansible.builtin.copy:
     src: zprofile-mac

--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -363,12 +363,15 @@
     src: zshrc-mac
     dest: "{{ lookup('env', 'HOME') }}/.zshrc"
     mode: "0644"
+    backup: true
+  changed_when: false
 
 - name: Copy zshenv file
   ansible.builtin.copy:
     src: zshenv-mac
     dest: "{{ lookup('env', 'HOME') }}/.zshenv"
     mode: "0644"
+    backup: true
   changed_when: false
 
 - name: Copy zprofile file
@@ -376,6 +379,8 @@
     src: zprofile-mac
     dest: "{{ lookup('env', 'HOME') }}/.zprofile"
     mode: "0644"
+    backup: true
+  changed_when: false
 
 # 1Password CLI Security Enhancements
 - name: Include 1Password security enhancements

--- a/roles/workstation/tasks/zprofile-linux
+++ b/roles/workstation/tasks/zprofile-linux
@@ -1,4 +1,2 @@
-# Source .zshrc if it exists
-if [ -f "$HOME/.zshrc" ]; then
-    source "$HOME/.zshrc"
-fi
+# Pro-Lazy "Safety Net": Ensure .zshrc is always sourced, even in login shells.
+[[ -f ~/.zshrc ]] && . ~/.zshrc

--- a/roles/workstation/tasks/zprofile-linux
+++ b/roles/workstation/tasks/zprofile-linux
@@ -1,2 +1,2 @@
-# Pro-Lazy "Safety Net": Ensure .zshrc is always sourced, even in login shells.
-[[ -f ~/.zshrc ]] && . ~/.zshrc
+# Pro-Lazy "Safety Net": Ensure .zshrc is sourced in interactive login shells.
+[[ -o interactive ]] && [[ -f ~/.zshrc ]] && . ~/.zshrc

--- a/roles/workstation/tasks/zprofile-mac
+++ b/roles/workstation/tasks/zprofile-mac
@@ -1,5 +1,5 @@
 # Set the oh-my-posh theme name globally
-OMP_THEME_NAME="night-owl.omp.json"
+export OMP_THEME_NAME="night-owl.omp.json"
 # OMP_THEME_NAME="atomic.omp.json"
 # OMP_THEME_NAME="clean-detailed.omp.json"
 # OMP_THEME_NAME="jandedobbeleer.omp.json"

--- a/roles/workstation/tasks/zprofile-mac
+++ b/roles/workstation/tasks/zprofile-mac
@@ -1,4 +1,10 @@
-# Source .zshrc if it exists
-if [ -f "$HOME/.zshrc" ]; then
-    source "$HOME/.zshrc"
-fi
+# Set the oh-my-posh theme name globally
+OMP_THEME_NAME="night-owl.omp.json"
+# OMP_THEME_NAME="atomic.omp.json"
+# OMP_THEME_NAME="clean-detailed.omp.json"
+# OMP_THEME_NAME="jandedobbeleer.omp.json"
+# OMP_THEME_NAME="kushal.omp.json"
+
+# Pro-Lazy "Safety Net": Ensure .zshrc is always sourced, even in login shells.
+# On macOS, every new terminal window is a login shell.
+[[ -f ~/.zshrc ]] && . ~/.zshrc

--- a/roles/workstation/tasks/zprofile-mac
+++ b/roles/workstation/tasks/zprofile-mac
@@ -5,6 +5,6 @@ OMP_THEME_NAME="night-owl.omp.json"
 # OMP_THEME_NAME="jandedobbeleer.omp.json"
 # OMP_THEME_NAME="kushal.omp.json"
 
-# Pro-Lazy "Safety Net": Ensure .zshrc is always sourced, even in login shells.
+# Pro-Lazy "Safety Net": Ensure .zshrc is sourced for interactive login shells.
 # On macOS, every new terminal window is a login shell.
-[[ -f ~/.zshrc ]] && . ~/.zshrc
+[[ -o interactive && -f ~/.zshrc ]] && . ~/.zshrc

--- a/roles/workstation/tasks/zshenv-linux
+++ b/roles/workstation/tasks/zshenv-linux
@@ -1,0 +1,16 @@
+# .zshenv for Linux
+# This file is loaded for EVERY instance of Zsh.
+# Use for global environment variables. No output allowed.
+
+# Path to Oh My Zsh installation
+export ZSH="$HOME/.oh-my-zsh"
+
+# Path management
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$PATH:$HOME/.local/bin"
+fi
+
+# Add Pulumi to PATH if installed
+if [ -d "$HOME/.pulumi/bin" ] && [[ ":$PATH:" != *":$HOME/.pulumi/bin:"* ]]; then
+    export PATH="$PATH:$HOME/.pulumi/bin"
+fi

--- a/roles/workstation/tasks/zshenv-mac
+++ b/roles/workstation/tasks/zshenv-mac
@@ -2,16 +2,28 @@
 # This file is loaded for EVERY instance of Zsh.
 # Use for global environment variables. No output allowed.
 
-# Initialize Homebrew
+# Initialize Homebrew without spawning external processes
 if [ -f "/opt/homebrew/bin/brew" ]; then
-    eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null)"
+    export BREW_PREFIX="/opt/homebrew"
 elif [ -f "/usr/local/bin/brew" ]; then
-    eval "$(/usr/local/bin/brew shellenv 2>/dev/null)"
+    export BREW_PREFIX="/usr/local"
 fi
 
-# Export BREW_PREFIX for other scripts to use
-if command -v brew >/dev/null 2>&1; then
-    export BREW_PREFIX="$(brew --prefix)/bin"
+# Add Homebrew paths if available
+if [ -n "${BREW_PREFIX:-}" ]; then
+    export HOMEBREW_PREFIX="$BREW_PREFIX"
+    export HOMEBREW_CELLAR="$BREW_PREFIX/Cellar"
+    export HOMEBREW_REPOSITORY="$BREW_PREFIX"
+
+    if [[ ":$PATH:" != *":$BREW_PREFIX/bin:"* ]]; then
+        export PATH="$BREW_PREFIX/bin:$PATH"
+    fi
+    if [[ ":$PATH:" != *":$BREW_PREFIX/sbin:"* ]]; then
+        export PATH="$BREW_PREFIX/sbin:$PATH"
+    fi
+
+    # Set BREW_PREFIX to bin path for other scripts
+    export BREW_PREFIX="$BREW_PREFIX/bin"
 fi
 
 # Path to Oh My Zsh installation
@@ -25,7 +37,3 @@ export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/
 if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
     export PATH="$PATH:$HOME/.local/bin"
 fi
-
-# Python environment
-export PYTHON_VENV_NAME=".venv"
-export PYTHON_AUTO_VRUN=true

--- a/roles/workstation/tasks/zshenv-mac
+++ b/roles/workstation/tasks/zshenv-mac
@@ -1,0 +1,31 @@
+# .zshenv for macOS
+# This file is loaded for EVERY instance of Zsh.
+# Use for global environment variables. No output allowed.
+
+# Initialize Homebrew
+if [ -f "/opt/homebrew/bin/brew" ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null)"
+elif [ -f "/usr/local/bin/brew" ]; then
+    eval "$(/usr/local/bin/brew shellenv 2>/dev/null)"
+fi
+
+# Export BREW_PREFIX for other scripts to use
+if command -v brew >/dev/null 2>&1; then
+    export BREW_PREFIX="$(brew --prefix)/bin"
+fi
+
+# Path to Oh My Zsh installation
+export ZSH="$HOME/.oh-my-zsh"
+
+# 1Password SSH Agent
+export SSH_AUTH_SOCK="$HOME/Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock"
+
+# Path management
+# Local bin
+if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+    export PATH="$PATH:$HOME/.local/bin"
+fi
+
+# Python environment
+export PYTHON_VENV_NAME=".venv"
+export PYTHON_AUTO_VRUN=true

--- a/roles/workstation/tasks/zshrc-linux
+++ b/roles/workstation/tasks/zshrc-linux
@@ -12,23 +12,10 @@ else
     OMP_THEME_CMD=""
 fi
 
-# PATH management
-if [ -d "$HOME/.local/bin" ] && [[ ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
-    export PATH="$PATH:$HOME/.local/bin"
-fi
-
-# Add Pulumi to PATH if installed
-if [ -d "$HOME/.pulumi/bin" ] && [[ ":$PATH:" != *":$HOME/.pulumi/bin:"* ]]; then
-    export PATH="$PATH:$HOME/.pulumi/bin"
-fi
-
 # Apply oh-my-posh theme if available
 if [ -n "$OMP_THEME_CMD" ]; then
     eval "$OMP_THEME_CMD"
 fi
-
-# Path to Oh My Zsh installation
-export ZSH="$HOME/.oh-my-zsh"
 
 # Python virtual environment configuration
 PYTHON_VENV_NAME=".venv"

--- a/roles/workstation/tasks/zshrc-mac
+++ b/roles/workstation/tasks/zshrc-mac
@@ -1,5 +1,6 @@
-
 # Oh-my-posh theme setup (change OMP_THEME_NAME to switch themes)
+: "${OMP_THEME_NAME:=night-owl.omp.json}"
+
 if [[ -n "$BREW_PREFIX" ]] && command -v "${BREW_PREFIX}/oh-my-posh" >/dev/null 2>&1 && command -v "${BREW_PREFIX}/brew" >/dev/null 2>&1; then
     OMP_THEME_CMD="$(${BREW_PREFIX}/oh-my-posh init zsh --config "$(${BREW_PREFIX}/brew --prefix oh-my-posh)/themes/$OMP_THEME_NAME")"
 else
@@ -21,8 +22,8 @@ fi
 set -o vi
 
 # Python auto env setup
-PYTHON_VENV_NAME=".venv"
-PYTHON_AUTO_VRUN=true
+export PYTHON_VENV_NAME=".venv"
+export PYTHON_AUTO_VRUN=true
 PYTHON_VENV_NAMES=($PYTHON_VENV_NAME venv)
 
 plugins=(git gh macos pip poetry python)

--- a/roles/workstation/tasks/zshrc-mac
+++ b/roles/workstation/tasks/zshrc-mac
@@ -1,9 +1,8 @@
 
 # Oh-my-posh theme setup (change OMP_THEME_NAME to switch themes)
-if command -v "${BREW_PREFIX}/oh-my-posh" >/dev/null 2>&1 && command -v "${BREW_PREFIX}/brew" >/dev/null 2>&1; then
+if [[ -n "$BREW_PREFIX" ]] && command -v "${BREW_PREFIX}/oh-my-posh" >/dev/null 2>&1 && command -v "${BREW_PREFIX}/brew" >/dev/null 2>&1; then
     OMP_THEME_CMD="$(${BREW_PREFIX}/oh-my-posh init zsh --config "$(${BREW_PREFIX}/brew --prefix oh-my-posh)/themes/$OMP_THEME_NAME")"
 else
-    echo "Could not set OMP_THEME_CMD" >&2
     OMP_THEME_CMD=""
 fi
 
@@ -13,8 +12,10 @@ if [ -n "$OMP_THEME_CMD" ]; then
     eval "$OMP_THEME_CMD"
 fi
 
-# Get all environment variables from the .env file
-eval "$(cat ~/.env | ${BREW_PREFIX}/op inject --)"
+# Get all environment variables from the .env file with guards
+if [[ -n "$BREW_PREFIX" ]] && [[ -f "$HOME/.env" ]] && command -v "${BREW_PREFIX}/op" >/dev/null 2>&1; then
+    eval "$(cat "$HOME/.env" | "${BREW_PREFIX}/op" inject --)"
+fi
 
 # Set vi mode
 set -o vi

--- a/roles/workstation/tasks/zshrc-mac
+++ b/roles/workstation/tasks/zshrc-mac
@@ -1,21 +1,3 @@
-# Set the oh-my-posh theme name globally
-OMP_THEME_NAME="night-owl.omp.json"
-# OMP_THEME_NAME="atomic.omp.json"
-# OMP_THEME_NAME="clean-detailed.omp.json"
-# OMP_THEME_NAME="jandedobbeleer.omp.json"
-# OMP_THEME_NAME="kushal.omp.json"
-
-# Initialize Homebrew first
-if [ -f "/opt/homebrew/bin/brew" ]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-elif [ -f "/usr/local/bin/brew" ]; then
-    eval "$(/usr/local/bin/brew shellenv)"
-else
-    echo "Homebrew not found" >&2
-fi
-
-# Now we can safely use brew commands
-BREW_PREFIX="$(brew --prefix)/bin"
 
 # Oh-my-posh theme setup (change OMP_THEME_NAME to switch themes)
 if command -v "${BREW_PREFIX}/oh-my-posh" >/dev/null 2>&1 && command -v "${BREW_PREFIX}/brew" >/dev/null 2>&1; then
@@ -25,10 +7,6 @@ else
     OMP_THEME_CMD=""
 fi
 
-# Homebrew
-if [ -x "$BREW_PREFIX/brew" ]; then
-    eval "$($BREW_PREFIX/brew shellenv)"
-fi
 
 # Setup oh-my-posh theme if defined
 if [ -n "$OMP_THEME_CMD" ]; then
@@ -46,10 +24,6 @@ PYTHON_VENV_NAME=".venv"
 PYTHON_AUTO_VRUN=true
 PYTHON_VENV_NAMES=($PYTHON_VENV_NAME venv)
 
-# Path to your Oh My Zsh installation
-export ZSH="$HOME/.oh-my-zsh"
-
-# Theme and plugins configuration
 plugins=(git gh macos pip poetry python)
 
 # Source Oh My Zsh
@@ -102,6 +76,3 @@ if [ -f "$HOME/.env" ]; then
         fi
     done
 fi
-
-# Setup 1Password SSH Agent
-export SSH_AUTH_SOCK=~/Library/Group\ Containers/2BUA8C4S2C.com.1password/t/agent.sock


### PR DESCRIPTION
## Description
This PR reorganizes the Zsh initialization files to follow best practices and the 'Pro-Lazy' strategy. It also adds a new AI agent skill for running local Mac workstation updates.

## Changes
- **New `.zshenv`**: Introduced for universal, silent environment variables (PATH, BREW_PREFIX, etc.).
- **Refactored `.zshrc`**: Cleaned up to focus on interactive shell features.
- **Refactored `.zprofile`**: Implemented the 'Safety Net' sourcing pattern and moved OMP_THEME_NAME to zprofile-mac.
- **New Skill**: Added `mac-workstation-update` at `.agents/skills/`.
- **Ansible Tasks**: Updated workstation roles to deploy the new configuration files.

## Verification
- Passed `make test-lint` (pre-commit and ansible-lint).
- Manually verified playbook execution.
