### PR TITLE
feat: symlink workstation workflows to gemini agents directory

### DIFF
--- a/roles/workstation/tasks/gemini-setup.yml
+++ b/roles/workstation/tasks/gemini-setup.yml
@@ -1,0 +1,21 @@
+---
+# ansible-task
+- name: Check for ~/.gemini directory
+  ansible.builtin.stat:
+    path: "{{ ansible_facts['env']['HOME'] }}/.gemini"
+  register: _workstation_gemini_stat
+
+- name: Check for ~/.agents/workflows directory
+  ansible.builtin.stat:
+    path: "{{ ansible_facts['env']['HOME'] }}/.agents/workflows"
+  register: _workstation_workflows_stat
+
+- name: Symlink workflows folder to Gemini agents folder
+  ansible.builtin.file:
+    src: "{{ ansible_facts['env']['HOME'] }}/.agents/workflows"
+    dest: "{{ ansible_facts['env']['HOME'] }}/.gemini/agents"
+    state: link
+    force: true
+  when:
+    - _workstation_gemini_stat.stat.exists
+    - _workstation_workflows_stat.stat.exists

--- a/roles/workstation/tasks/gemini-setup.yml
+++ b/roles/workstation/tasks/gemini-setup.yml
@@ -17,5 +17,5 @@
     state: link
     force: true
   when:
-    - _workstation_gemini_stat.stat.exists
-    - _workstation_workflows_stat.stat.exists
+    - _workstation_gemini_stat.stat.isdir
+    - _workstation_workflows_stat.stat.isdir

--- a/roles/workstation/tasks/main.yml
+++ b/roles/workstation/tasks/main.yml
@@ -6,3 +6,6 @@
 - name: Include local-linux tasks if Linux
   ansible.builtin.include_tasks: local-linux.yml
   when: ansible_facts['system'] == 'Linux'
+
+- name: Include gemini-setup tasks
+  ansible.builtin.include_tasks: gemini-setup.yml


### PR DESCRIPTION
## Description
This PR adds a new task to the workstation role to automatically symlink the `~/.agents/workflows` folder into the `~/.gemini/agents` directory. This ensures that custom agent workflows are available to the Gemini system in a cross-platform manner.

## Changes
- Created `roles/workstation/tasks/gemini-setup.yml` with stat and symlink tasks.
- Integrated the new tasks into the main workstation role.

## Verification
- Validated via `make test-lint` and `make test-syntax`.
- Manually verified the symlink creation on the local machine.