### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,8 @@ jobs:
   pr-gatekeeper:
     name: PR Gatekeeper
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     if: github.event_name == 'pull_request'
     steps:
       - name: Check for 'ready-to-merge' label

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,8 +118,7 @@ jobs:
   pr-gatekeeper:
     name: PR Gatekeeper
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
+    permissions: {}
     if: github.event_name == 'pull_request'
     steps:
       - name: Check for 'ready-to-merge' label


### PR DESCRIPTION
Potential fix for [https://github.com/davidasnider/ansible_home/security/code-scanning/6](https://github.com/davidasnider/ansible_home/security/code-scanning/6)

Add an explicit `permissions` block to the `pr-gatekeeper` job in `.github/workflows/ci.yml`.  
Best minimal fix without changing behavior: set `contents: read`, which is sufficient for a job that only evaluates PR context and runs shell checks (no write operations). This satisfies CodeQL and enforces least privilege.

Edit location:
- File: `.github/workflows/ci.yml`
- Region: `pr-gatekeeper` job (around lines 118–123)
- Change: insert
  ```yml
  permissions:
    contents: read
  ```
  directly under `runs-on`.

No imports, methods, or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
