### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
     types: [opened, synchronize, reopened, labeled, unlabeled]
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   ansible-lint:
     name: Ansible Linting


### PR DESCRIPTION
Potential fix for [https://github.com/davidasnider/ansible_home/security/code-scanning/7](https://github.com/davidasnider/ansible_home/security/code-scanning/7)

Add an explicit top-level `permissions` block in `.github/workflows/ci.yml` so all jobs default to least privilege.

Best single fix:
- Insert at workflow root (after `on:` block, before `jobs:`):
  - `permissions:`
  - `contents: read`

Why this is best:
- It resolves the CodeQL finding for the whole workflow at once.
- It preserves current behavior for read-only jobs (checkout/lint/scanning).
- If hidden jobs need write access, they can add job-level `permissions` overrides later without removing this secure baseline.

No imports/dependencies/methods are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
