### PR TITLE
fix: avoid interactive setup during Hermes Agent installation

### DIFF
--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -404,7 +404,7 @@
   until: workstation_hermes_download_result is succeeded
 
 - name: Install Hermes Agent
-  ansible.builtin.shell: "{{ workstation_hermes_tmpdir.path }}/install.sh"
+  ansible.builtin.shell: "{{ workstation_hermes_tmpdir.path }}/install.sh --skip-setup"
   args:
     executable: /bin/bash
   become: false

--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -404,9 +404,10 @@
   until: workstation_hermes_download_result is succeeded
 
 - name: Install Hermes Agent
-  ansible.builtin.shell: "{{ workstation_hermes_tmpdir.path }}/install.sh --skip-setup"
-  args:
-    executable: /bin/bash
+  ansible.builtin.command:
+    argv:
+      - "{{ workstation_hermes_tmpdir.path }}/install.sh"
+      - --skip-setup
   become: false
   when: workstation_hermes_check.rc != 0
   register: workstation_hermes_install_result


### PR DESCRIPTION
This prevents the install script from failing in non-interactive Ansible shells due to /dev/tty being unavailable.