### PR TITLE
feat(workstation): install imsg homebrew package on macOS

### DIFF
--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -175,14 +175,17 @@
       {{ (workstation_brew_update_stat.stat.exists and ((ansible_facts['date_time']['epoch'] | int) - (workstation_brew_update_stat.stat.mtime | int) > 86400))
          or (not workstation_brew_update_stat.stat.exists) }}
 
-- name: Add OpenCode tap
+- name: Add Homebrew taps
   community.general.homebrew_tap:
-    name: anomalyco/tap
+    name: "{{ item }}"
     state: present
-  register: workstation_opencode_tap_result
+  loop:
+    - anomalyco/tap
+    - steipete/tap
+  register: workstation_homebrew_tap_result
   retries: 3
   delay: 5
-  until: workstation_opencode_tap_result is succeeded
+  until: workstation_homebrew_tap_result is succeeded
 
 - name: Update Homebrew and install packages
   community.general.homebrew:
@@ -194,6 +197,7 @@
       - pre-commit
       - pulumi
       - opencode
+      - imsg
       - zsh-autocomplete
       - zsh-autosuggestions
       - zsh-syntax-highlighting


### PR DESCRIPTION
### Summary
This PR adds the `imsg` package to the macOS workstation configuration.

### Changes
- Added `steipete/tap` to Homebrew taps in `roles/workstation/tasks/local-mac.yml`.
- Refactored tap addition to use a loop for better maintainability.
- Added `imsg` to the list of Homebrew packages to be installed.

### Verification
- Ran `ansible-playbook --syntax-check` (passed).
- Applied changes using `mac-workstation-update` skill (successful).
- Verified `imsg --version` returns `0.5.0` on the local machine.