### PR TITLE
feat: add antigravity-cli and remove omlx

### DIFF
--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -190,7 +190,6 @@
 - name: Update Homebrew and install packages
   community.general.homebrew:
     name:
-      - antigravity-cli
       - gh
       - htop
       - macmon
@@ -295,6 +294,7 @@
     - name: Install other Homebrew casks
       community.general.homebrew_cask:
         name:
+          - antigravity-cli
           - iterm2
           - visual-studio-code
           - orbstack

--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -190,6 +190,7 @@
 - name: Update Homebrew and install packages
   community.general.homebrew:
     name:
+      - antigravity-cli
       - gh
       - htop
       - macmon
@@ -209,6 +210,30 @@
   delay: 5
   timeout: 300
 
+- name: Setup omlx
+  block:
+    - name: Add omlx Homebrew tap
+      community.general.homebrew_tap:
+        name: jundot/omlx
+        url: https://github.com/jundot/omlx
+        state: present
+
+    - name: Install and upgrade omlx
+      community.general.homebrew:
+        name: omlx
+        state: latest
+        update_homebrew: "{{ workstation_update_brew }}"
+
+    - name: Ensure omlx service is started
+      community.general.homebrew_services:
+        name: omlx
+        state: present
+
+    - name: Install MCP support for omlx
+      ansible.builtin.pip:
+        name: mcp
+        executable: /opt/homebrew/opt/omlx/libexec/bin/pip
+
 - name: Verify Homebrew packages installation
   ansible.builtin.command: gh --version
   register: workstation_gh_version_check
@@ -218,9 +243,20 @@
   delay: 5
   until: workstation_gh_version_check.rc == 0
 
+- name: Verify omlx installation
+  ansible.builtin.command: /opt/homebrew/bin/omlx -h
+  register: workstation_omlx_version_check
+  changed_when: false
+  failed_when: workstation_omlx_version_check.rc != 0
+  retries: 3
+  delay: 5
+  until: workstation_omlx_version_check.rc == 0
+
 - name: Debug Homebrew packages installation check
   ansible.builtin.debug:
-    var: workstation_gh_version_check
+    msg:
+      - "gh version: {{ workstation_gh_version_check.stdout }}"
+      - "omlx help output: {{ workstation_omlx_version_check.stdout | default('N/A') }}"
     verbosity: 2
 
 - name: Install Homebrew casks with security verification

--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -209,30 +209,6 @@
   delay: 5
   timeout: 300
 
-- name: Setup omlx
-  block:
-    - name: Add omlx Homebrew tap
-      community.general.homebrew_tap:
-        name: jundot/omlx
-        url: https://github.com/jundot/omlx
-        state: present
-
-    - name: Install and upgrade omlx
-      community.general.homebrew:
-        name: omlx
-        state: latest
-        update_homebrew: "{{ workstation_update_brew }}"
-
-    - name: Ensure omlx service is started
-      community.general.homebrew_services:
-        name: omlx
-        state: present
-
-    - name: Install MCP support for omlx
-      ansible.builtin.pip:
-        name: mcp
-        executable: /opt/homebrew/opt/omlx/libexec/bin/pip
-
 - name: Verify Homebrew packages installation
   ansible.builtin.command: gh --version
   register: workstation_gh_version_check
@@ -242,20 +218,9 @@
   delay: 5
   until: workstation_gh_version_check.rc == 0
 
-- name: Verify omlx installation
-  ansible.builtin.command: /opt/homebrew/bin/omlx -h
-  register: workstation_omlx_version_check
-  changed_when: false
-  failed_when: workstation_omlx_version_check.rc != 0
-  retries: 3
-  delay: 5
-  until: workstation_omlx_version_check.rc == 0
-
 - name: Debug Homebrew packages installation check
   ansible.builtin.debug:
-    msg:
-      - "gh version: {{ workstation_gh_version_check.stdout }}"
-      - "omlx help output: {{ workstation_omlx_version_check.stdout | default('N/A') }}"
+    var: workstation_gh_version_check
     verbosity: 2
 
 - name: Install Homebrew casks with security verification

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,0 +1,30 @@
+import os
+import pytest
+import subprocess
+import sys
+from pathlib import Path
+
+@pytest.mark.unit
+def test_missing_github_token_raises_error(tmp_path):
+    """Test that missing GITHUB_TOKEN environment variable raises a ValueError."""
+    # 1. Absolute path to the script
+    repo_root = Path(__file__).resolve().parent.parent
+    main_file = repo_root / "infrastructure" / "__main__.py"
+
+    # 2. .env and env isolation: Copy environment but remove GITHUB_TOKEN
+    env = os.environ.copy()
+    if "GITHUB_TOKEN" in env:
+        del env["GITHUB_TOKEN"]
+
+    # 3. CWD isolation: Run subprocess from temporary directory
+    # Using python executable directly so it processes the script
+    result = subprocess.run(
+        [sys.executable, str(main_file)],
+        cwd=str(tmp_path),
+        env=env,
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode != 0
+    assert "ValueError: GITHUB_TOKEN environment variable is required" in result.stderr

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,24 +1,18 @@
-import os
 import runpy
-import tempfile
 import pytest
-import subprocess
-import sys
 from pathlib import Path
 
 
 @pytest.mark.unit
-def test_missing_github_token_raises_error(tmp_path):
+def test_missing_github_token_raises_error(tmp_path, monkeypatch):
     """Test that missing GITHUB_TOKEN environment variable raises a ValueError."""
     # Derive the absolute path to infrastructure/__main__.py from this file's location
     script_path = Path(__file__).resolve().parent.parent / "infrastructure/__main__.py"
 
     # Run from a temp directory so load_dotenv() won't discover a local .env
     # in the repo root, and the absolute script path ensures CWD doesn't matter.
-    with tempfile.TemporaryDirectory() as tmpdir:
-        os.chdir(tmpdir)
-        with pytest.MonkeyPatch.context() as m:
-            m.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
-            with pytest.raises(ValueError, match="GITHUB_TOKEN environment variable is required"):
-                runpy.run_path(str(script_path), run_name="__main__")
+    with pytest.raises(ValueError, match="GITHUB_TOKEN environment variable is required"):
+        runpy.run_path(str(script_path), run_name="__main__")

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,30 +1,24 @@
 import os
+import runpy
+import tempfile
 import pytest
 import subprocess
 import sys
 from pathlib import Path
 
+
 @pytest.mark.unit
 def test_missing_github_token_raises_error(tmp_path):
     """Test that missing GITHUB_TOKEN environment variable raises a ValueError."""
-    # 1. Absolute path to the script
-    repo_root = Path(__file__).resolve().parent.parent
-    main_file = repo_root / "infrastructure" / "__main__.py"
+    # Derive the absolute path to infrastructure/__main__.py from this file's location
+    script_path = Path(__file__).resolve().parent.parent / "infrastructure/__main__.py"
 
-    # 2. .env and env isolation: Copy environment but remove GITHUB_TOKEN
-    env = os.environ.copy()
-    if "GITHUB_TOKEN" in env:
-        del env["GITHUB_TOKEN"]
+    # Run from a temp directory so load_dotenv() won't discover a local .env
+    # in the repo root, and the absolute script path ensures CWD doesn't matter.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        with pytest.MonkeyPatch.context() as m:
+            m.delenv("GITHUB_TOKEN", raising=False)
 
-    # 3. CWD isolation: Run subprocess from temporary directory
-    # Using python executable directly so it processes the script
-    result = subprocess.run(
-        [sys.executable, str(main_file)],
-        cwd=str(tmp_path),
-        env=env,
-        capture_output=True,
-        text=True
-    )
-
-    assert result.returncode != 0
-    assert "ValueError: GITHUB_TOKEN environment variable is required" in result.stderr
+            with pytest.raises(ValueError, match="GITHUB_TOKEN environment variable is required"):
+                runpy.run_path(str(script_path), run_name="__main__")


### PR DESCRIPTION
## Summary
This PR adds `antigravity-cli` to the Homebrew Casks list in the workstation role and removes the now-redundant `omlx` command-line management tasks.

## Changes
- Added `antigravity-cli` to `community.general.homebrew_cask` in `roles/workstation/tasks/local-mac.yml`.
- Removed `omlx` related tasks from `roles/workstation/tasks/local-mac.yml`.

## Technical Details
- `antigravity-cli` is now managed via Homebrew Cask which is the preferred installation method for macOS workstations in this repo.
- The `omlx` tasks were removed as they are no longer required.

## Verification
- Verified that `antigravity-cli` is present in the task file.
- Verified that `omlx` references are removed.
- Ran static analysis and unit tests.