### PR TITLE
fix(ci): block auto-merge and auto-approve when 'ready-to-merge' label is missing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,9 +130,9 @@ jobs:
             echo "✅ 'ready-to-merge' label found. Proceeding..."
             exit 0
           else
-            echo "❌ Missing 'ready-to-merge' label. Warning only."
+            echo "❌ Missing 'ready-to-merge' label."
             echo "Please review the changes and add the label once ready."
-            exit 0
+            exit 1
           fi
 
   auto-approve:


### PR DESCRIPTION
## Description
This PR fixes a bug in the CI workflow where pull requests were automatically approved and merged even if the required `ready-to-merge` label was not added.

### Cause of the Issue
The `pr-gatekeeper` job checked for the `ready-to-merge` label, but exited with status code `0` (success) when the label was missing. As a result:
1. `pr-gatekeeper` succeeded.
2. `auto-approve` (which needs `pr-gatekeeper`) ran and auto-approved the PR.
3. `auto-merge` (which needs `auto-approve`) ran and merged the PR.

### Solution
Updated [.github/workflows/ci.yml](file:///Users/david/code/ansible_home/.github/workflows/ci.yml) to exit with status code `1` in the `else` block of the `Check for 'ready-to-merge' label` step:
- Print a failure message.
- Exit `1` to fail the `pr-gatekeeper` job.
- This correctly prevents downstream jobs `auto-approve` and `auto-merge` from running.

## Verification
- Verified by running all validation checks locally (`make test`), which completed successfully.
- Verified that all unit tests (`uv run pytest`) passed.