### PR TITLE
feat(workstation): add obsidian to homebrew casks

### DIFF
--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -264,6 +264,7 @@
           - visual-studio-code
           - orbstack
           - rectangle
+          - obsidian
         state: present
       retries: 3
       delay: 5


### PR DESCRIPTION
Add Obsidian to the list of Homebrew casks in the workstation configuration for macOS. Verified that the workstation playbook runs cleanly and successfully installs Obsidian.