### PR TITLE
docs: update README with antigravity-cli

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 503,
+        "line_number": 504,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-05-18T03:31:08Z"
+  "generated_at": "2026-06-08T03:32:20Z"
 }

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ The current framework structure will extend to support:
 # Homebrew casks
 - 1password
 - 1password-cli
+- antigravity-cli
 - iterm2
 - visual-studio-code
 - orbstack


### PR DESCRIPTION
Updates the README.md file to include `antigravity-cli` in the Homebrew casks list, reflecting recent changes to the macOS workstation configuration.

Also includes updates to `.secrets.baseline` generated by `detect-secrets` due to line numbers shifting in the README.

---
*PR created automatically by Jules for task [8626351011734478654](https://jules.google.com/task/8626351011734478654) started by @davidasnider*