### PR TITLE
docs: sync testing documentation and test code with subprocess

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -168,26 +168,32 @@ For infrastructure as code and Python utilities, tests are placed in the `tests/
 """Test cases for infrastructure scripts."""
 
 import pytest
-import runpy
-import dotenv
+import subprocess
+import sys
 from pathlib import Path
 
 @pytest.mark.unit
 def test_missing_env_raises_error(tmp_path, monkeypatch):
     """Test that missing required environment variables raise errors."""
-    repo_root = Path(__file__).resolve().parent.parent
-    main_file = repo_root / "infrastructure" / "__main__.py"
+    script_path = Path(__file__).resolve().parent.parent / "infrastructure/__main__.py"
 
-    # Isolate current working directory
-    monkeypatch.chdir(tmp_path)
-
-    # Remove variables and patch dotenv to prevent loading from local .env files
+    # Remove GITHUB_TOKEN from environment if it exists
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.setattr(dotenv, "load_dotenv", lambda *args, **kwargs: None)
 
-    # Execute the script
-    with pytest.raises(ValueError, match="GITHUB_TOKEN environment variable is required"):
-        runpy.run_path(str(main_file))
+    import os
+    env = os.environ.copy()
+
+    # Execute the file as a subprocess from a temporary directory for strict environment isolation
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode != 0
+    assert "GITHUB_TOKEN environment variable is required" in result.stderr
 ```
 
 ### Molecule Test File Structure (`roles/*/molecule/`)

--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,23 +1,27 @@
 import pytest
-import runpy
+import subprocess
+import sys
 from pathlib import Path
-import dotenv
 
 @pytest.mark.unit
 def test_missing_github_token_raises_error(tmp_path, monkeypatch):
-    """Test that missing GITHUB_TOKEN environment variable raises a ValueError."""
-    # Derive the absolute path to infrastructure/__main__.py from this file's location
+    """Test that missing GITHUB_TOKEN environment variable raises an error."""
     script_path = Path(__file__).resolve().parent.parent / "infrastructure/__main__.py"
-
-    # Run from a temp directory so load_dotenv() won't discover a local .env
-    # in the repo root, and the absolute script path ensures CWD doesn't matter.
-    monkeypatch.chdir(tmp_path)
 
     # Remove GITHUB_TOKEN from environment if it exists
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
-    # .env isolation: patch load_dotenv so it's a no-op, preventing any .env file from repopulating
-    monkeypatch.setattr(dotenv, "load_dotenv", lambda *args, **kwargs: None)
+    import os
+    env = os.environ.copy()
 
-    with pytest.raises(ValueError, match="GITHUB_TOKEN environment variable is required"):
-        runpy.run_path(str(script_path), run_name="__main__")
+    # Execute the file as a subprocess from a temporary directory for strict environment isolation
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True
+    )
+
+    assert result.returncode != 0
+    assert "GITHUB_TOKEN environment variable is required" in result.stderr


### PR DESCRIPTION
This PR updates the infrastructure testing documentation (`docs/TESTING.md`) and the actual test implementation (`tests/test_infrastructure.py`) to align with recent refactoring efforts. It switches the `test_missing_github_token_raises_error` test from using `runpy` (with monkeypatched `dotenv`) to using `subprocess.run` with a copied and modified environment. This approach provides significantly stricter environment isolation and prevents state bleeding or local `.env` pollution when executing tests via `pytest`.

---
*PR created automatically by Jules for task [725168538794526307](https://jules.google.com/task/725168538794526307) started by @davidasnider*