### PR TITLE
docs: update PR approval process with ready-to-merge label requirement

### DIFF
--- a/docs/PR_APPROVAL_PROCESS.md
+++ b/docs/PR_APPROVAL_PROCESS.md
@@ -20,6 +20,9 @@ All of the following automated checks must pass before a PR can be approved:
 #### Coverage & Quality
 - ✅ **Test Coverage Report** - Test coverage analysis and reporting
 
+#### PR Label Checks
+- ✅ **ready-to-merge label** - The CI pipeline checks for the `ready-to-merge` label and will exit with status code 1 if it is missing. This label is required to proceed with merge.
+
 #### Legacy Checks (if configured)
 - 📝 Ansible Linting
 - 🔒 Pre-commit Checks
@@ -124,6 +127,7 @@ After approval and all checks passing:
 ## 🚫 What Prevents PR Approval
 
 ### Automated Blocks
+- Missing `ready-to-merge` label
 - Any failing status check
 - Unsigned commits (if signed commits required)
 - Unresolved security alerts


### PR DESCRIPTION
Updates the `docs/PR_APPROVAL_PROCESS.md` file to properly document the CI pipeline requirement that checks for the `ready-to-merge` label before allowing a PR to merge. The workflow will now correctly exit with status code 1 if the label is missing, acting as an automated block. This change ensures the documentation remains in sync with recent changes to the CI pipeline configurations.

---
*PR created automatically by Jules for task [14537166030427792811](https://jules.google.com/task/14537166030427792811) started by @davidasnider*