### PR TITLE
docs: update outdated localhost role paths to workstation

### DIFF
--- a/docs/1PASSWORD_SECURITY.md
+++ b/docs/1PASSWORD_SECURITY.md
@@ -213,13 +213,13 @@ grep "ERROR\|WARN" ~/.config/op/op-secure.log
 The security enhancements are implemented across several components:
 
 ### Ansible Tasks
-- `roles/localhost/tasks/1password-security.yml`: Core security module
-- `roles/localhost/tasks/local-mac.yml`: macOS-specific integration
-- `roles/localhost/tasks/local-linux.yml`: Linux-specific integration
+- `roles/workstation/tasks/1password-security.yml`: Core security module
+- `roles/workstation/tasks/local-mac.yml`: macOS-specific integration
+- `roles/workstation/tasks/local-linux.yml`: Linux-specific integration
 
 ### Test Coverage
-- `roles/localhost/molecule/macos/tests/test_macos_specific.py`: macOS security tests
-- `roles/localhost/molecule/linux/tests/test_linux_specific.py`: Linux security tests
+- `roles/workstation/molecule/macos/tests/test_macos_specific.py`: macOS security tests
+- `roles/workstation/molecule/linux/tests/test_linux_specific.py`: Linux security tests
 
 ### Security Scripts
 - `~/.local/bin/op-secure`: Enhanced CLI wrapper

--- a/docs/GIT_SECURITY.md
+++ b/docs/GIT_SECURITY.md
@@ -90,7 +90,7 @@ This script will:
    ```
 
 4. **Update Ansible configuration**:
-   - Modify `roles/localhost/tasks/local-linux.yml`
+   - Modify `roles/workstation/tasks/local-linux.yml`
    - Update the signing key in both the Git config and allowed_signers tasks
 
 5. **Remove old key** (after verification):

--- a/docs/PR_APPROVAL_PROCESS.md
+++ b/docs/PR_APPROVAL_PROCESS.md
@@ -207,7 +207,7 @@ uv run ansible-lint roles/
 ### Molecule Test Failures
 ```bash
 # Debug specific test scenario
-cd roles/localhost
+cd roles/workstation
 uv run molecule test -s default --debug
 
 # Check test logs

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -86,7 +86,7 @@ open htmlcov/index.html
 ## Test Structure
 
 ```
-roles/localhost/molecule/
+roles/workstation/molecule/
 ├── default/                 # Default test scenario
 │   ├── molecule.yml        # Molecule configuration
 │   ├── converge.yml        # Test playbook
@@ -144,7 +144,7 @@ The `.github/workflows/molecule.yml` workflow:
 ### pytest Configuration (`pyproject.toml`)
 ```toml
 [tool.pytest.ini_options]
-testpaths = ["roles/localhost/molecule", "tests"]
+testpaths = ["roles/workstation/molecule", "tests"]
 addopts = [
     "--cov=roles",
     "--cov-report=html",
@@ -241,7 +241,7 @@ docker system prune -f
 #### Test Failures
 ```bash
 # Run specific test with verbose output
-cd roles/localhost
+cd roles/workstation
 uv run molecule test -s default --debug
 ```
 


### PR DESCRIPTION
- Updated the documentation to accurately reflect the recent refactor where `roles/localhost` was renamed to `roles/workstation`.
- Replaced all instances of `roles/localhost` with `roles/workstation` in `docs/1PASSWORD_SECURITY.md`, `docs/GIT_SECURITY.md`, `docs/PR_APPROVAL_PROCESS.md`, and `docs/TESTING.md`.
- Completed 3 rounds of GitHub Copilot reviews and validated the changes with `make test`.

---
*PR created automatically by Jules for task [1275290030007381363](https://jules.google.com/task/1275290030007381363) started by @davidasnider*