### PR TITLE
feat(workstation): install pi-coding-agent on macOS and trust third-party taps

### DIFF
--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -187,6 +187,14 @@
   delay: 5
   until: workstation_homebrew_tap_result is succeeded
 
+- name: Trust Homebrew taps
+  ansible.builtin.command: /opt/homebrew/bin/brew trust "{{ item }}"
+  loop:
+    - anomalyco/tap
+    - steipete/tap
+  changed_when: false
+  failed_when: false
+
 - name: Update Homebrew and install packages
   community.general.homebrew:
     name:
@@ -203,6 +211,7 @@
       - zsh-autosuggestions
       - zsh-syntax-highlighting
       - zsh-history-substring-search
+      - pi-coding-agent
     state: present
     update_homebrew: "{{ workstation_update_brew }}"
   retries: 3


### PR DESCRIPTION
### Summary
This PR adds the `pi-coding-agent` (Pi coding harness) to the macOS workstation configuration. It also fixes Homebrew tap loading issues by explicitly trusting `anomalyco/tap` and `steipete/tap` before package installation.

### Key Changes
- **Trust third-party taps:** Added a task in `roles/workstation/tasks/local-mac.yml` to run `brew trust` on configured taps (`anomalyco/tap` and `steipete/tap`) to comply with Tap Trust security in newer Homebrew versions.
- **Install `pi-coding-agent`:** Added `pi-coding-agent` to the list of Homebrew formulae in `roles/workstation/tasks/local-mac.yml`.

### Verification Steps
1. Ran `make test` to verify playbook syntax and formatting/lint checks.
2. Successfully executed the `workstations.yml` playbook against localhost.
3. Verified the installation location using `which pi` (`/opt/homebrew/bin/pi`).
