### PR TITLE
docs: sync README with recently added packages and casks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 502,
+        "line_number": 505,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-06-17T17:07:19Z"
+  "generated_at": "2026-06-18T03:25:07Z"
 }

--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ The current framework structure will extend to support:
 
 ### Package Management
 - **Homebrew**: Primary package manager with automatic installation
-- **Formulae**: Command-line tools (gh, htop, oh-my-posh, uv, pre-commit, pulumi, opencode, imsg)
-- **Casks**: GUI applications and fonts (1Password, 1Password CLI, iTerm2, VS Code, OrbStack, Rectangle, font-meslo-lg-nerd-font)
+- **Formulae**: Command-line tools (gh, htop, oh-my-posh, uv, pre-commit, pulumi, opencode, imsg, pi-coding-agent)
+- **Casks**: GUI applications and fonts (Antigravity CLI, 1Password, 1Password CLI, iTerm2, VS Code, OrbStack, Rectangle, Obsidian, font-meslo-lg-nerd-font)
 - **Update Strategy**: Checks last update time, only updates if >24 hours old
 
 ### Key Features
@@ -220,13 +220,16 @@ The current framework structure will extend to support:
 - zsh-autosuggestions
 - zsh-syntax-highlighting
 - zsh-history-substring-search
+- pi-coding-agent
 # Homebrew casks
+- antigravity-cli
 - 1password
 - 1password-cli
 - iterm2
 - visual-studio-code
 - orbstack
 - rectangle
+- obsidian
 - font-meslo-lg-nerd-font
 
 # Custom scripts/binaries


### PR DESCRIPTION
Update `README.md` to ensure `pi-coding-agent`, `obsidian`, and `antigravity-cli` are listed in the Homebrew packages and casks sections, matching the additions in the Ansible playbooks (`roles/workstation/tasks/local-mac.yml`). Also committed the detect-secrets baseline file updates.

---
*PR created automatically by Jules for task [2073987839129046850](https://jules.google.com/task/2073987839129046850) started by @davidasnider*