### PR TITLE
fix: reorder casks to match playbook order, add macmon to formulae list

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ The current framework structure will extend to support:
 
 ### Package Management
 - **Homebrew**: Primary package manager with automatic installation
-- **Formulae**: Command-line tools (gh, htop, oh-my-posh, uv, pre-commit, pulumi, opencode, imsg, pi-coding-agent)
-- **Casks**: GUI applications and fonts (Antigravity CLI, 1Password, 1Password CLI, iTerm2, VS Code, OrbStack, Rectangle, Obsidian, font-meslo-lg-nerd-font)
+- **Formulae**: Command-line tools (gh, htop, macmon, oh-my-posh, uv, pre-commit, pulumi, opencode, imsg, pi-coding-agent)
+- **Casks**: GUI applications and fonts (1Password, 1Password CLI, Antigravity CLI, iTerm2, VS Code, OrbStack, Rectangle, Obsidian, font-meslo-lg-nerd-font)
 - **Update Strategy**: Checks last update time, only updates if >24 hours old
 
 ### Key Features
@@ -222,9 +222,9 @@ The current framework structure will extend to support:
 - zsh-history-substring-search
 - pi-coding-agent
 # Homebrew casks
-- antigravity-cli
 - 1password
 - 1password-cli
+- antigravity-cli
 - iterm2
 - visual-studio-code
 - orbstack


### PR DESCRIPTION
This PR addresses 2 documentation review findings from the agy review on PR #121:

1. **Cask ordering** — The inline list and YAML code block listed `Antigravity CLI` before `1Password` and `1Password CLI`, but the playbook (`roles/workstation/tasks/local-mac.yml`) installs 1Password/1Password CLI first for security verification before other casks. Reordered to match execution order.

2. **Missing `macmon` from inline Formulae list** — `macmon` was present in the YAML code block but missing from the inline description. Added it in alphabetical position.