### PR TITLE
docs: fix README formulae list and cask classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ The current framework structure will extend to support:
 
 ### Package Management
 - **Homebrew**: Primary package manager with automatic installation
-- **Formulae**: Command-line tools (gh, htop, macmon, oh-my-posh, uv, pre-commit, pulumi, opencode, imsg, pi-coding-agent)
-- **Casks**: GUI applications and fonts (1Password, 1Password CLI, Antigravity CLI, iTerm2, VS Code, OrbStack, Rectangle, Obsidian, font-meslo-lg-nerd-font)
+- **Formulae**: Command-line tools (gh, htop, macmon, oh-my-posh, uv, pre-commit, pulumi, opencode, imsg, pi-coding-agent, zsh-autocomplete, zsh-autosuggestions, zsh-history-substring-search, zsh-syntax-highlighting)
+- **Casks**: GUI applications, command-line utilities, and fonts (1Password, 1Password CLI, Antigravity CLI, iTerm2, VS Code, OrbStack, Rectangle, Obsidian, font-meslo-lg-nerd-font)
 - **Update Strategy**: Checks last update time, only updates if >24 hours old
 
 ### Key Features


### PR DESCRIPTION
Resolves 2 agy review findings from PR #121:

1. **Formulae list inconsistency** — Added missing shell integration tools (`zsh-autocomplete`, `zsh-autosuggestions`, `zsh-history-substring-search`, `zsh-syntax-highlighting`) to the inline Formulae summary paragraph to match the YAML block.

2. **CLI Casks classification** — Updated Casks description from "GUI applications and fonts" to "GUI applications, command-line utilities, and fonts" to accurately reflect that the list includes CLI tools (1Password CLI, Antigravity CLI).

Both changes are in README.md only.