### PR TITLE
🧪 [Testing Improvement] Add Error Test for Missing GITHUB_TOKEN

### DIFF
--- a/tests/test_infrastructure.py
+++ b/tests/test_infrastructure.py
@@ -1,50 +1,27 @@
 import os
+import pytest
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
-import pytest
-
-_TEST_DIR = Path(__file__).resolve().parent
-_PROJECT_ROOT = _TEST_DIR.parent
-
-
 @pytest.mark.unit
-def test_missing_github_token_raises_error():
-    """Test that missing GITHUB_TOKEN environment variable raises a ValueError.
+def test_missing_github_token_raises_error(tmp_path, monkeypatch):
+    """Test that missing GITHUB_TOKEN environment variable raises an error."""
+    script_path = Path(__file__).resolve().parent.parent / "infrastructure/__main__.py"
 
-    Uses a subprocess so the test is fully isolated:
-    - No local .env file is discovered (the script runs in a temp dir).
-    - The GITHUB_TOKEN is explicitly unset in the subprocess env.
-    """
-    main_module = _PROJECT_ROOT / "infrastructure" / "__main__.py"
+    # Remove GITHUB_TOKEN from environment if it exists
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
 
-    # Get the site-packages dir from the current Python so deps (pulumi, dotenv)
-    # are importable in the subprocess.
-    site_packages = (
-        subprocess.check_output(
-            [sys.executable, "-c", "import sysconfig; print(sysconfig.get_path('purelib'))"],
-            text=True,
-        ).strip()
+    env = os.environ.copy()
+
+    # Execute the file as a subprocess from a temporary directory for strict environment isolation
+    result = subprocess.run(
+        [sys.executable, str(script_path)],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True
     )
 
-    # Start from a clean env (no GITHUB_TOKEN, no dotenv leakage).
-    clean_env = {k: v for k, v in os.environ.items() if k != "GITHUB_TOKEN"}
-    existing = clean_env.get("PYTHONPATH", "")
-    new_entries = str(_PROJECT_ROOT) + os.pathsep + site_packages
-    clean_env["PYTHONPATH"] = new_entries if not existing else existing + os.pathsep + new_entries
-
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        result = subprocess.run(
-            [sys.executable, str(main_module)],
-            capture_output=True,
-            text=True,
-            env=clean_env,
-            cwd=tmp_dir,
-        )
-
-        assert result.returncode != 0, (
-            f"Expected ValueError but script succeeded. stderr: {result.stderr}"
-        )
-        assert "GITHUB_TOKEN environment variable is required" in result.stderr
+    assert result.returncode != 0
+    assert "GITHUB_TOKEN environment variable is required" in result.stderr


### PR DESCRIPTION
🎯 **What:** The previous test logic for `GITHUB_TOKEN` environment validation in `infrastructure/__main__.py` was overly complex, involving manual `PYTHONPATH` hacking and `tempfile` management. This PR completely refactors the missing environment variable test to use simple, idiomatic `pytest` features (`tmp_path` and `monkeypatch.delenv`).

📊 **Coverage:** Specifically validates the failure path for when the `GITHUB_TOKEN` is unset or omitted from `.env`.

✨ **Result:** Test coverage and strict isolation remain correct but the maintainability and readability of `test_infrastructure.py` have substantially improved.

---
*PR created automatically by Jules for task [5921017015072738912](https://jules.google.com/task/5921017015072738912) started by @davidasnider*