### PR TITLE
docs: sync testing documentation with recent pytest changes

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -179,6 +179,7 @@ def test_functionality(host):
 3. **Error Messages**: Provide meaningful assertion messages
 4. **Platform Awareness**: Consider platform differences in tests
 5. **Idempotency**: Ensure tests can run multiple times safely
+6. **Environment Isolation**: Use idiomatic `pytest` fixtures like `tmp_path` and `monkeypatch.delenv` for strict environment isolation in subprocess execution, rather than manual `tempfile` handling or `runpy`.
 
 ## Troubleshooting
 


### PR DESCRIPTION
This PR updates `docs/TESTING.md` to include a new guideline about using idiomatic `pytest` fixtures like `tmp_path` and `monkeypatch.delenv` for strict environment isolation in subprocess execution, reflecting recent refactoring in the testing suite.

---
*PR created automatically by Jules for task [2884382247345435151](https://jules.google.com/task/2884382247345435151) started by @davidasnider*