### PR TITLE
docs: update TESTING.md CI workflow reference

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -125,7 +125,7 @@ roles/workstation/molecule/
 ## CI/CD Integration
 
 ### GitHub Actions Workflow
-The `.github/workflows/molecule.yml` workflow:
+The `.github/workflows/ci.yml` workflow:
 1. **Lint Stage**: Runs ansible-lint on all roles
 2. **Test Matrix**: Executes multiple scenarios in parallel
 3. **Coverage**: Generates and uploads coverage reports


### PR DESCRIPTION
Updates `docs/TESTING.md` to correctly reference the `.github/workflows/ci.yml` workflow instead of `.github/workflows/molecule.yml`.
Also verified `README.md` is in sync with recent additions in `local-mac.yml` and `local-linux.yml` (e.g. `macmon`, `pi-coding-agent`, `obsidian`, `antigravity-cli`).
Passed all `make test` verification steps.

---
*PR created automatically by Jules for task [10253369021388140809](https://jules.google.com/task/10253369021388140809) started by @davidasnider*