### PR TITLE
docs: sync documentation with linux packages and PR gatekeeper requirement

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 504,
+        "line_number": 506,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-06-20T03:21:13Z"
+  "generated_at": "2026-06-28T03:39:12Z"
 }

--- a/README.md
+++ b/README.md
@@ -232,6 +232,8 @@ The current framework structure will extend to support:
 - font-meslo-lg-nerd-font
 
 # Custom scripts/binaries
+- pulumi
+- opencode
 - hermes-agent
 ```
 

--- a/docs/PR_APPROVAL_PROCESS.md
+++ b/docs/PR_APPROVAL_PROCESS.md
@@ -34,6 +34,7 @@ All of the following automated checks must pass before a PR can be approved:
 - **Conversation Resolution**: All PR conversations must be resolved before merge
 
 ### Additional Protections
+- **Require 'ready-to-merge' Label**: The PR Gatekeeper CI check requires the `ready-to-merge` label to pass.
 - **Require Signed Commits**: `true` - All commits must be GPG signed
 - **Require Linear History**: `true` - No merge commits, only squash/rebase
 - **Allow Force Pushes**: `false` - Force pushes to main branch are blocked


### PR DESCRIPTION
This PR synchronizes the project documentation with recent codebase changes.
It adds missing custom scripts/binaries (`pulumi`, `opencode`) to the Linux-Specific Packages section in `README.md` and updates `docs/PR_APPROVAL_PROCESS.md` to explicitly note the `ready-to-merge` label requirement enforced by the PR Gatekeeper CI check.

---
*PR created automatically by Jules for task [3261052443509466259](https://jules.google.com/task/3261052443509466259) started by @davidasnider*