### PR TITLE
🧹 Code Health: Extract duplicated Oh My Zsh installation logic into shared tasks file

### DIFF
--- a/roles/workstation/tasks/install-oh-my-zsh.yml
+++ b/roles/workstation/tasks/install-oh-my-zsh.yml
@@ -1,0 +1,43 @@
+---
+- name: Check if Oh My Zsh is installed
+  ansible.builtin.stat:
+    path: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
+  register: workstation_oh_my_zsh_stat
+
+- name: Debug Oh My Zsh stat
+  ansible.builtin.debug:
+    var: workstation_oh_my_zsh_stat
+    verbosity: 2
+
+- name: Install Oh My Zsh with error handling
+  block:
+    - name: Install Oh My Zsh if not present
+      ansible.builtin.shell: |
+        sh -c "$(curl -fsSL -m 300 https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
+      args:
+        creates: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
+      when: not workstation_oh_my_zsh_stat.stat.exists
+      changed_when: false
+      register: workstation_oh_my_zsh_install_result
+      retries: 3
+      delay: 5
+      until: workstation_oh_my_zsh_install_result.rc == 0
+
+    - name: Verify Oh My Zsh installation
+      ansible.builtin.stat:
+        path: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
+      register: workstation_oh_my_zsh_stat_check
+
+    - name: Fail if Oh My Zsh is not installed
+      ansible.builtin.fail:
+        msg: "Oh My Zsh installation failed. The directory ~/.oh-my-zsh was not found."
+      when: not workstation_oh_my_zsh_stat_check.stat.exists
+  rescue:
+    - name: Fail if Oh My Zsh installation failed
+      ansible.builtin.fail:
+        msg: "Oh My Zsh installation failed. Please check the logs for more details."
+
+- name: Debug Oh My Zsh installation result
+  ansible.builtin.debug:
+    var: workstation_oh_my_zsh_install_result
+    verbosity: 2

--- a/roles/workstation/tasks/local-linux.yml
+++ b/roles/workstation/tasks/local-linux.yml
@@ -350,48 +350,9 @@
   when: not (ansible_facts.virtualization_type is defined and ansible_facts.virtualization_type == 'docker')
   failed_when: false
 
-- name: Check if Oh My Zsh is installed
-  ansible.builtin.stat:
-    path: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
-  register: workstation_oh_my_zsh_stat
-
-- name: Debug Oh My Zsh stat
-  ansible.builtin.debug:
-    var: workstation_oh_my_zsh_stat
-    verbosity: 2
-
-- name: Install Oh My Zsh with error handling
-  block:
-    - name: Install Oh My Zsh if not present
-      ansible.builtin.shell: |
-        sh -c "$(curl -fsSL -m 300 https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-      args:
-        creates: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
-      when: not workstation_oh_my_zsh_stat.stat.exists
-      changed_when: false
-      register: workstation_oh_my_zsh_install_result
-      retries: 3
-      delay: 5
-      until: workstation_oh_my_zsh_install_result.rc == 0
-
-    - name: Verify Oh My Zsh installation
-      ansible.builtin.stat:
-        path: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
-      register: workstation_oh_my_zsh_stat_check_linux
-
-    - name: Fail if Oh My Zsh is not installed
-      ansible.builtin.fail:
-        msg: "Oh My Zsh installation failed. The directory ~/.oh-my-zsh was not found."
-      when: not workstation_oh_my_zsh_stat_check_linux.stat.exists
-  rescue:
-    - name: Fail if Oh My Zsh installation failed
-      ansible.builtin.fail:
-        msg: "Oh My Zsh installation failed. Please check the logs for more details."
-
-- name: Debug Oh My Zsh installation result
-  ansible.builtin.debug:
-    var: workstation_oh_my_zsh_install_result
-    verbosity: 2
+- name: Include Oh My Zsh installation tasks
+  ansible.builtin.include_tasks:
+    file: install-oh-my-zsh.yml
 
 
 - name: Copy zshrc file

--- a/roles/workstation/tasks/local-mac.yml
+++ b/roles/workstation/tasks/local-mac.yml
@@ -355,44 +355,9 @@
       echo "GPG format: $(git config --global gpg.format || echo 'Not set')"
       echo "Commit signing enabled: $(git config --global commit.gpgsign || echo 'Not set')"
 
-- name: Check if Oh My Zsh is installed
-  ansible.builtin.stat:
-    path: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
-  register: workstation_oh_my_zsh_stat
-
-
-- name: Install Oh My Zsh with error handling
-  block:
-    - name: Install Oh My Zsh if not present
-      ansible.builtin.shell: |
-        sh -c "$(curl -fsSL -m 300 https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-      args:
-        creates: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
-      when: not workstation_oh_my_zsh_stat.stat.exists
-      changed_when: false
-      register: workstation_oh_my_zsh_install_result
-      retries: 3
-      delay: 5
-      until: workstation_oh_my_zsh_install_result.rc == 0
-
-    - name: Verify Oh My Zsh installation
-      ansible.builtin.stat:
-        path: "{{ ansible_facts['env']['HOME'] }}/.oh-my-zsh"
-      register: workstation_oh_my_zsh_stat_check
-
-    - name: Fail if Oh My Zsh is not installed
-      ansible.builtin.fail:
-        msg: "Oh My Zsh installation failed. The directory ~/.oh-my-zsh was not found."
-      when: not workstation_oh_my_zsh_stat_check.stat.exists
-  rescue:
-    - name: Fail if Oh My Zsh installation failed
-      ansible.builtin.fail:
-        msg: "Oh My Zsh installation failed. Please check the logs for more details."
-
-- name: Debug Oh My Zsh installation result
-  ansible.builtin.debug:
-    var: workstation_oh_my_zsh_install_result
-    verbosity: 2
+- name: Include Oh My Zsh installation tasks
+  ansible.builtin.include_tasks:
+    file: install-oh-my-zsh.yml
 
 - name: Check if Hermes Agent is installed
   ansible.builtin.command: which hermes


### PR DESCRIPTION
🎯 **What:** Extracted the Oh My Zsh installation logic into a shared task file (`roles/workstation/tasks/install-oh-my-zsh.yml`).
💡 **Why:** The exact same logic was duplicated in both the Mac and Linux workstation tasks. Extracting it into a reusable file improves code maintainability and adherence to DRY principles.
✅ **Verification:** Verified by checking syntax via `make test-syntax`, running formatting checks using `make test-lint`, running tests via `make test`, and verifying the logical structure manually through `git diff`.
✨ **Result:** Reduced duplication across OS-specific workstation playbooks, allowing future modifications to the Oh My Zsh installation process to be made in a single place.

---
*PR created automatically by Jules for task [12997359212960501130](https://jules.google.com/task/12997359212960501130) started by @davidasnider*