### PR TITLE
docs: reflect extracted Oh My Zsh installation logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ The current framework structure will extend to support:
 ## Common Tasks Across Platforms
 - Git user configuration (name and email)
 - `~/code` directory creation
-- Oh My Zsh installation and configuration
+- Oh My Zsh installation and configuration (extracted to `roles/workstation/tasks/install-oh-my-zsh.yml`)
 - Zsh plugin management (syntax highlighting, autosuggestions)
 - oh-my-posh theme engine setup
 - Python virtual environment detection and auto-activation


### PR DESCRIPTION
Updates the README.md to accurately reflect that the "Oh My Zsh installation and configuration" logic was extracted to `roles/workstation/tasks/install-oh-my-zsh.yml`, maintaining sync with recent refactoring in commit c23f754.

---
*PR created automatically by Jules for task [7541491405684899111](https://jules.google.com/task/7541491405684899111) started by @davidasnider*