### PR TITLE
docs: Update documentation for Ansible tasks structure and Git security

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 534,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-07-03T18:28:23Z"
+  "generated_at": "2026-07-20T03:20:56Z"
 }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ ansible_home/
 │       │   └── main.yml        # Event handlers
 │       └── tasks/
 │           ├── main.yml        # Role entry point (OS detection)
-│           ├── local-linux.yml # Linux-specific tasks
+│           ├── local-linux.yml # Linux entry point
+│           ├── local-linux-packages.yml # Linux package management
+│           ├── local-linux-shell.yml # Linux shell config
+│           ├── setup-git.yml   # Global Git configuration
 │           ├── local-mac.yml   # macOS-specific tasks
 │           ├── zshrc-linux     # Linux zsh configuration template
 ├── src/
@@ -64,7 +67,7 @@ ansible_home/
 ### OS Detection Pattern (Standard Role Architecture)
 The `workstation` role uses a standard `tasks/main.yml` entry point to detect the operating system and delegate to platform-specific logic:
 - `ansible_facts['system'] == 'Darwin'` → includes `local-mac.yml`
-- `ansible_facts['system'] == 'Linux'` → includes `local-linux.yml`
+- `ansible_facts['system'] == 'Linux'` → includes `local-linux.yml` (which delegates to `-packages` and `-shell`)
 
 ### Configuration Management
 - **Templates**: Shell configuration files (like `zshrc-linux`) are stored as templates
@@ -297,7 +300,7 @@ The current framework structure will extend to support:
 - **Linux**: 1Password CLI-only with manual GPG key and repository setup
 
 ## Common Tasks Across Platforms
-- Git user configuration (name and email)
+- Git user configuration and SSH key setup (`roles/workstation/tasks/setup-git.yml`)
 - `~/code` directory creation
 - Oh My Zsh installation and configuration (extracted to `roles/workstation/tasks/install-oh-my-zsh.yml`)
 - Zsh plugin management (syntax highlighting, autosuggestions)
@@ -426,7 +429,7 @@ The `GITHUB_TOKEN` environment variable is required for certain infrastructure a
 
 #### Linux (APT)
 ```yaml
-# Add to roles/workstation/tasks/local-linux.yml
+# Add to roles/workstation/tasks/local-linux-packages.yml
 - name: Install packages
   ansible.builtin.apt:
     name:

--- a/docs/1PASSWORD_SECURITY.md
+++ b/docs/1PASSWORD_SECURITY.md
@@ -215,7 +215,8 @@ The security enhancements are implemented across several components:
 ### Ansible Tasks
 - `roles/workstation/tasks/1password-security.yml`: Core security module
 - `roles/workstation/tasks/local-mac.yml`: macOS-specific integration
-- `roles/workstation/tasks/local-linux.yml`: Linux-specific integration
+- `roles/workstation/tasks/local-linux-packages.yml`: Linux-specific integration (CLI installation)
+- `roles/workstation/tasks/setup-git.yml`: SSH and Git signing integration
 
 ### Test Coverage
 - `roles/workstation/molecule/macos/tests/test_macos_specific.py`: macOS security tests

--- a/docs/GIT_SECURITY.md
+++ b/docs/GIT_SECURITY.md
@@ -90,7 +90,7 @@ This script will:
    ```
 
 4. **Update Ansible configuration**:
-   - Modify `roles/workstation/tasks/local-linux.yml` and `roles/workstation/tasks/local-mac.yml`
+   - Modify `roles/workstation/tasks/setup-git.yml`
    - Update the signing key in both the Git config and allowed_signers tasks
 
 5. **Remove old key** (after verification):


### PR DESCRIPTION
- Updated `README.md` to reflect the newly refactored Ansible structure, where `local-linux.yml` delegates to smaller task files (`-packages.yml` and `-shell.yml`) and `setup-git.yml` is used for global configuration.
- Fixed references in the `Linux (APT)` package installation block to correctly point to `local-linux-packages.yml`.
- Fixed the Git user configuration and SSH key setup reference in the "Common Tasks Across Platforms" section to point to `setup-git.yml`.
- Corrected instructions in `docs/GIT_SECURITY.md` for key rotation processes to point users to the new `setup-git.yml` file.
- Corrected `docs/1PASSWORD_SECURITY.md` to point to `local-linux-packages.yml` and `setup-git.yml` for proper integration reference.
- Addressed `detect-secrets` modifications to `.secrets.baseline` to pass linting.

---
*PR created automatically by Jules for task [10085937343684583551](https://jules.google.com/task/10085937343684583551) started by @davidasnider*