### PR TITLE
docs: Update documentation to reflect Ansible refactoring

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 538,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-07-03T18:28:23Z"
+  "generated_at": "2026-07-24T03:21:19Z"
 }

--- a/README.md
+++ b/README.md
@@ -46,8 +46,11 @@ ansible_home/
 │       │   └── main.yml        # Event handlers
 │       └── tasks/
 │           ├── main.yml        # Role entry point (OS detection)
-│           ├── local-linux.yml # Linux-specific tasks
+│           ├── local-linux.yml # Linux entry point
+│           ├── local-linux-packages.yml # Linux package management
+│           ├── local-linux-shell.yml    # Linux shell & user config
 │           ├── local-mac.yml   # macOS-specific tasks
+│           ├── setup-git.yml   # Shared global Git and SSH configuration
 │           ├── zshrc-linux     # Linux zsh configuration template
 ├── src/
 │   └── steel_mountain_ansible/    # Python package structure
@@ -245,6 +248,10 @@ The current framework structure will extend to support:
 
 ## Linux Configuration (`roles/workstation/tasks/local-linux.yml`)
 
+Tasks are split into logical components:
+- `local-linux-packages.yml`: Package management (APT, GitHub CLI, 1Password CLI, etc.)
+- `local-linux-shell.yml`: Shell configuration (Zsh, oh-my-posh)
+
 ### Package Management
 - **APT**: Uses apt package manager for Ubuntu/Debian systems
 - **Cache Management**: Updates cache with 24-hour validity period
@@ -297,7 +304,7 @@ The current framework structure will extend to support:
 - **Linux**: 1Password CLI-only with manual GPG key and repository setup
 
 ## Common Tasks Across Platforms
-- Git user configuration (name and email)
+- Git user configuration (name and email), GPG signing, SSH config, and key validation (extracted to `roles/workstation/tasks/setup-git.yml`)
 - `~/code` directory creation
 - Oh My Zsh installation and configuration (extracted to `roles/workstation/tasks/install-oh-my-zsh.yml`)
 - Zsh plugin management (syntax highlighting, autosuggestions)
@@ -426,7 +433,7 @@ The `GITHUB_TOKEN` environment variable is required for certain infrastructure a
 
 #### Linux (APT)
 ```yaml
-# Add to roles/workstation/tasks/local-linux.yml
+# Add to roles/workstation/tasks/local-linux-packages.yml
 - name: Install packages
   ansible.builtin.apt:
     name:

--- a/docs/GIT_SECURITY.md
+++ b/docs/GIT_SECURITY.md
@@ -90,7 +90,7 @@ This script will:
    ```
 
 4. **Update Ansible configuration**:
-   - Modify `roles/workstation/tasks/local-linux.yml` and `roles/workstation/tasks/local-mac.yml`
+   - Modify `roles/workstation/tasks/setup-git.yml`
    - Update the signing key in both the Git config and allowed_signers tasks
 
 5. **Remove old key** (after verification):


### PR DESCRIPTION
This pull request updates the documentation in `README.md` and `docs/GIT_SECURITY.md` to accurately reflect recent code modifications. Specifically:

1. Updates `README.md` to show that `local-linux.yml` has been split into `local-linux-packages.yml` and `local-linux-shell.yml` (from commit 44af06d).
2. Updates `README.md` and `docs/GIT_SECURITY.md` to document the centralization of global Git configurations into `setup-git.yml` (from commit 11a0c3c).
3. Updates the `.secrets.baseline` file to account for changes to the line numbers in documentation files.

---
*PR created automatically by Jules for task [6655750563318998030](https://jules.google.com/task/6655750563318998030) started by @davidasnider*