### PR TITLE
docs: sync documentation with linux playbook refactoring

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 540,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-07-03T18:28:23Z"
+  "generated_at": "2026-07-28T03:24:45Z"
 }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,10 @@ ansible_home/
 │       │   └── main.yml        # Event handlers
 │       └── tasks/
 │           ├── main.yml        # Role entry point (OS detection)
-│           ├── local-linux.yml # Linux-specific tasks
+│           ├── local-linux.yml # Linux entry point
+│           ├── local-linux-packages.yml # Linux packages
+│           ├── local-linux-shell.yml # Linux shell configuration
+│           ├── setup-git.yml # Shared Git configuration
 │           ├── local-mac.yml   # macOS-specific tasks
 │           ├── zshrc-linux     # Linux zsh configuration template
 ├── src/
@@ -245,6 +248,12 @@ The current framework structure will extend to support:
 
 ## Linux Configuration (`roles/workstation/tasks/local-linux.yml`)
 
+The Linux configuration has been modularized into separate components for better maintainability:
+- `local-linux.yml`: Main entry point that orchestrates the sub-playbooks.
+- `local-linux-packages.yml`: Handles package installation.
+- `local-linux-shell.yml`: Manages shell configurations and Oh My Zsh.
+- `setup-git.yml`: Shared Git configuration across platforms.
+
 ### Package Management
 - **APT**: Uses apt package manager for Ubuntu/Debian systems
 - **Cache Management**: Updates cache with 24-hour validity period
@@ -426,7 +435,7 @@ The `GITHUB_TOKEN` environment variable is required for certain infrastructure a
 
 #### Linux (APT)
 ```yaml
-# Add to roles/workstation/tasks/local-linux.yml
+# Add to roles/workstation/tasks/local-linux-packages.yml
 - name: Install packages
   ansible.builtin.apt:
     name:

--- a/docs/1PASSWORD_SECURITY.md
+++ b/docs/1PASSWORD_SECURITY.md
@@ -215,7 +215,7 @@ The security enhancements are implemented across several components:
 ### Ansible Tasks
 - `roles/workstation/tasks/1password-security.yml`: Core security module
 - `roles/workstation/tasks/local-mac.yml`: macOS-specific integration
-- `roles/workstation/tasks/local-linux.yml`: Linux-specific integration
+- `roles/workstation/tasks/local-linux.yml` (and `local-linux-packages.yml`): Linux-specific integration
 
 ### Test Coverage
 - `roles/workstation/molecule/macos/tests/test_macos_specific.py`: macOS security tests

--- a/docs/GIT_SECURITY.md
+++ b/docs/GIT_SECURITY.md
@@ -90,7 +90,7 @@ This script will:
    ```
 
 4. **Update Ansible configuration**:
-   - Modify `roles/workstation/tasks/local-linux.yml` and `roles/workstation/tasks/local-mac.yml`
+   - Modify `roles/workstation/tasks/setup-git.yml`, `roles/workstation/tasks/local-linux-shell.yml` (and other platform specific playbooks)
    - Update the signing key in both the Git config and allowed_signers tasks
 
 5. **Remove old key** (after verification):


### PR DESCRIPTION
This PR updates `README.md`, `docs/1PASSWORD_SECURITY.md`, and `docs/GIT_SECURITY.md` to accurately reflect the recent modularization of the Linux configuration playbooks.

- The Linux configuration was previously centralized in `roles/workstation/tasks/local-linux.yml`.
- It has since been split into `local-linux.yml` (entry point), `local-linux-packages.yml`, `local-linux-shell.yml`, and `setup-git.yml`.
- Updated all relevant markdown files and code snippets to point to the correct files.
- Added updated secrets baseline after formatting updates.

---
*PR created automatically by Jules for task [17973149926463896788](https://jules.google.com/task/17973149926463896788) started by @davidasnider*