### PR TITLE
docs: update documentation to reflect ansible workstation refactoring

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 536,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-07-03T18:28:23Z"
+  "generated_at": "2026-07-31T03:23:27Z"
 }

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ ansible_home/
 │       └── tasks/
 │           ├── main.yml        # Role entry point (OS detection)
 │           ├── local-linux.yml # Linux-specific tasks
+│           ├── local-linux-packages.yml # Linux package installations
+│           ├── local-linux-shell.yml    # Linux shell configuration
 │           ├── local-mac.yml   # macOS-specific tasks
+│           ├── setup-git.yml   # Global Git configuration
 │           ├── zshrc-linux     # Linux zsh configuration template
 ├── src/
 │   └── steel_mountain_ansible/    # Python package structure
@@ -243,7 +246,7 @@ The current framework structure will extend to support:
 - hermes-agent
 ```
 
-## Linux Configuration (`roles/workstation/tasks/local-linux.yml`)
+## Linux Configuration (`roles/workstation/tasks/local-linux-packages.yml` and `roles/workstation/tasks/local-linux-shell.yml`)
 
 ### Package Management
 - **APT**: Uses apt package manager for Ubuntu/Debian systems
@@ -426,14 +429,17 @@ The `GITHUB_TOKEN` environment variable is required for certain infrastructure a
 
 #### Linux (APT)
 ```yaml
-# Add to roles/workstation/tasks/local-linux.yml
-- name: Install packages
+# Add to roles/workstation/tasks/local-linux-packages.yml
+- name: Install a package and update cache if needed
+  become: true
   ansible.builtin.apt:
     name:
       - existing-package
       - new-package-name  # Add here
     state: present
-    update_cache: yes
+    update_cache: true
+    cache_valid_time: 86400 # in seconds, equals 24 hours
+  when: not workstation_optimized_base_check.stat.exists
 ```
 
 ### Modifying Shell Configuration
@@ -446,11 +452,10 @@ plugins=(git gh pip python systemd new-plugin)
 ```
 
 #### Update Zsh Configuration (macOS)
-Modify the `ansible.builtin.blockinfile` task in `local-mac.yml`:
-```yaml
-block: |
-  # Add new configuration here
-  source /opt/homebrew/share/new-plugin/new-plugin.zsh
+Edit `roles/workstation/tasks/zshrc-mac` template:
+```bash
+# Add new configuration here
+source /opt/homebrew/share/new-plugin/new-plugin.zsh
 ```
 
 ### Testing Changes

--- a/docs/GIT_SECURITY.md
+++ b/docs/GIT_SECURITY.md
@@ -90,7 +90,7 @@ This script will:
    ```
 
 4. **Update Ansible configuration**:
-   - Modify `roles/workstation/tasks/local-linux.yml` and `roles/workstation/tasks/local-mac.yml`
+   - Modify `roles/workstation/tasks/setup-git.yml`
    - Update the signing key in both the Git config and allowed_signers tasks
 
 5. **Remove old key** (after verification):


### PR DESCRIPTION
This PR addresses recent refactoring to the Ansible workstation role. It updates the directory tree in `README.md` to reflect the newly split Linux configuration files (`local-linux-packages.yml`, `local-linux-shell.yml`), the new global Git configuration (`setup-git.yml`), and updates the macOS shell configuration reference to use the template (`zshrc-mac`). It updates code snippets to use the new file locations and correct Ansible parameters (like `cache_valid_time`). Finally, it correctly updates `GIT_SECURITY.md` to point to the new `setup-git.yml` file.

---
*PR created automatically by Jules for task [7249892051480646235](https://jules.google.com/task/7249892051480646235) started by @davidasnider*