### PR TITLE
docs: sync documentation with recent refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ The current framework structure will extend to support:
 - hermes-agent
 ```
 
-## Linux Configuration (`roles/workstation/tasks/local-linux.yml`)
+## Linux Configuration (`roles/workstation/tasks/local-linux-packages.yml`)
 
 ### Package Management
 - **APT**: Uses apt package manager for Ubuntu/Debian systems
@@ -426,7 +426,7 @@ The `GITHUB_TOKEN` environment variable is required for certain infrastructure a
 
 #### Linux (APT)
 ```yaml
-# Add to roles/workstation/tasks/local-linux.yml
+# Add to roles/workstation/tasks/local-linux-packages.yml
 - name: Install packages
   ansible.builtin.apt:
     name:

--- a/docs/1PASSWORD_SECURITY.md
+++ b/docs/1PASSWORD_SECURITY.md
@@ -215,7 +215,7 @@ The security enhancements are implemented across several components:
 ### Ansible Tasks
 - `roles/workstation/tasks/1password-security.yml`: Core security module
 - `roles/workstation/tasks/local-mac.yml`: macOS-specific integration
-- `roles/workstation/tasks/local-linux.yml`: Linux-specific integration
+- `roles/workstation/tasks/local-linux.yml` (and its included tasks): Linux-specific integration
 
 ### Test Coverage
 - `roles/workstation/molecule/macos/tests/test_macos_specific.py`: macOS security tests

--- a/docs/GIT_SECURITY.md
+++ b/docs/GIT_SECURITY.md
@@ -90,7 +90,7 @@ This script will:
    ```
 
 4. **Update Ansible configuration**:
-   - Modify `roles/workstation/tasks/local-linux.yml` and `roles/workstation/tasks/local-mac.yml`
+   - Modify `roles/workstation/tasks/setup-git.yml`
    - Update the signing key in both the Git config and allowed_signers tasks
 
 5. **Remove old key** (after verification):


### PR DESCRIPTION
Updates `README.md`, `docs/1PASSWORD_SECURITY.md`, and `docs/GIT_SECURITY.md` to accurately reflect the recent refactoring that split `local-linux.yml` into smaller components (like `local-linux-packages.yml`) and centralized global Git configurations into `setup-git.yml`.

---
*PR created automatically by Jules for task [6786853422827477284](https://jules.google.com/task/6786853422827477284) started by @davidasnider*