### PR TITLE
docs: synchronize documentation with recent refactoring

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 531,
+        "line_number": 539,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-07-03T18:28:23Z"
+  "generated_at": "2026-08-02T03:19:19Z"
 }

--- a/README.md
+++ b/README.md
@@ -45,10 +45,16 @@ ansible_home/
 │       ├── handlers/
 │       │   └── main.yml        # Event handlers
 │       └── tasks/
-│           ├── main.yml        # Role entry point (OS detection)
-│           ├── local-linux.yml # Linux-specific tasks
-│           ├── local-mac.yml   # macOS-specific tasks
-│           ├── zshrc-linux     # Linux zsh configuration template
+│           ├── main.yml                 # Role entry point (OS detection)
+│           ├── local-linux.yml          # Linux-specific task entry point
+│           ├── local-linux-packages.yml # Linux package installations
+│           ├── local-linux-shell.yml    # Linux shell configuration
+│           ├── local-mac.yml            # macOS-specific tasks
+│           ├── setup-git.yml            # Global Git configuration
+│           ├── 1password-security.yml   # 1Password security enhancements
+│           ├── install-oh-my-zsh.yml    # Oh My Zsh installation
+│           ├── gemini-setup.yml         # Gemini prompt setup
+│           ├── zshrc-linux              # Linux zsh configuration template
 ├── src/
 │   └── steel_mountain_ansible/    # Python package structure
 └── tests/                     # Test files
@@ -245,7 +251,9 @@ The current framework structure will extend to support:
 
 ## Linux Configuration (`roles/workstation/tasks/local-linux.yml`)
 
-### Package Management
+The `local-linux.yml` file serves as the main entry point for Linux configuration, which has been split into logical components for better maintainability:
+
+### Package Management (`local-linux-packages.yml`)
 - **APT**: Uses apt package manager for Ubuntu/Debian systems
 - **Cache Management**: Updates cache with 24-hour validity period
 - **System Integration**: Sets zsh as default shell system-wide

--- a/docs/1PASSWORD_SECURITY.md
+++ b/docs/1PASSWORD_SECURITY.md
@@ -214,8 +214,8 @@ The security enhancements are implemented across several components:
 
 ### Ansible Tasks
 - `roles/workstation/tasks/1password-security.yml`: Core security module
-- `roles/workstation/tasks/local-mac.yml`: macOS-specific integration
-- `roles/workstation/tasks/local-linux.yml`: Linux-specific integration
+- `roles/workstation/tasks/local-mac.yml`: macOS-specific integration (invokes security enhancements)
+- `roles/workstation/tasks/local-linux-packages.yml`: Linux-specific package installations (including 1Password CLI)
 
 ### Test Coverage
 - `roles/workstation/molecule/macos/tests/test_macos_specific.py`: macOS security tests

--- a/docs/GIT_SECURITY.md
+++ b/docs/GIT_SECURITY.md
@@ -90,7 +90,7 @@ This script will:
    ```
 
 4. **Update Ansible configuration**:
-   - Modify `roles/workstation/tasks/local-linux.yml` and `roles/workstation/tasks/local-mac.yml`
+   - Modify `roles/workstation/tasks/setup-git.yml`
    - Update the signing key in both the Git config and allowed_signers tasks
 
 5. **Remove old key** (after verification):


### PR DESCRIPTION
Updates `README.md`, `docs/GIT_SECURITY.md`, and `docs/1PASSWORD_SECURITY.md` to accurately reflect recent code modifications where monolithic Ansible task files were split into modular components. 

Specifically:
- Updated directory tree in `README.md` to show newly separated files (`setup-git.yml`, `local-linux-packages.yml`, etc.)
- Updated `GIT_SECURITY.md` references to point to `setup-git.yml` instead of the OS-specific monolith files.
- Updated `1PASSWORD_SECURITY.md` to reference `local-linux-packages.yml` for 1Password CLI installation.
- Fixed detect-secrets baseline mutations from shifting file line numbers.

---
*PR created automatically by Jules for task [15303698830972870646](https://jules.google.com/task/15303698830972870646) started by @davidasnider*