### PR TITLE
docs: synchronize documentation with recent refactoring

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 539,
+        "line_number": 538,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-08-02T03:19:19Z"
+  "generated_at": "2026-08-14T03:22:36Z"
 }

--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ The `GITHUB_TOKEN` environment variable is required for certain infrastructure a
 
 #### Linux (APT)
 ```yaml
-# Add to roles/workstation/tasks/local-linux.yml
+# Add to roles/workstation/tasks/local-linux-packages.yml
 - name: Install packages
   ansible.builtin.apt:
     name:
@@ -454,11 +454,10 @@ plugins=(git gh pip python systemd new-plugin)
 ```
 
 #### Update Zsh Configuration (macOS)
-Modify the `ansible.builtin.blockinfile` task in `local-mac.yml`:
-```yaml
-block: |
-  # Add new configuration here
-  source /opt/homebrew/share/new-plugin/new-plugin.zsh
+Modify the `roles/workstation/tasks/zshrc-mac` template:
+```bash
+# Add new configuration here
+source /opt/homebrew/share/new-plugin/new-plugin.zsh
 ```
 
 ### Testing Changes


### PR DESCRIPTION
This PR updates `README.md` to accurately reflect recent refactoring changes in the Ansible task file structure, ensuring documentation aligns with the current implementation.

Specifically:
- Updates the Linux package addition example to target `roles/workstation/tasks/local-linux-packages.yml` instead of the legacy `local-linux.yml`.
- Updates the macOS Zsh configuration example to instruct modifying the new `roles/workstation/tasks/zshrc-mac` template rather than editing an inline `blockinfile` module in `local-mac.yml`.
- Refreshes the `detect-secrets` baseline (`.secrets.baseline`) to account for shifted line numbers caused by these modifications.

Validation tests (`make test`, `make test-lint`, `make test-syntax`) were completely successful and showed zero regressions. Copilot reviews were requested three times and resolved correctly.

---
*PR created automatically by Jules for task [2745266546389137995](https://jules.google.com/task/2745266546389137995) started by @davidasnider*