### PR TITLE
chore: update bootstrap and agent skills to use site.yml

### DIFF
--- a/.agents/skills/mac-workstation-update/SKILL.md
+++ b/.agents/skills/mac-workstation-update/SKILL.md
@@ -4,11 +4,11 @@ description: Runs the Ansible playbook to update the local macOS workstation con
 ---
 
 1. Validates that the current system is macOS.
-2. Executes the `workstations.yml` playbook using uv to ensure all local configurations, tools, and security settings are up to date.
+2. Executes the `site.yml` playbook using uv to ensure all local configurations, tools, and security settings are up to date.
 
 ### Prerequisites
 
-- Run this skill from the repository root so relative paths such as `inventory/hosts.yml` and `playbooks/workstations.yml` resolve correctly.
+- Run this skill from the repository root so relative paths such as `inventory/hosts.yml` and `site.yml` resolve correctly.
 - Export `ANSIBLE_SUDO_PASS` in your environment before running this skill; the playbook reads it for `ansible_become_pass`.
 - Ensure `uv` is installed and the project dependencies needed for `ansible-playbook` are available.
 - This skill is intended only for macOS.
@@ -21,6 +21,6 @@ if [[ "$(uname)" != "Darwin" ]]; then
 fi
 
 echo "🚀 Updating local macOS workstation..."
-uv run ansible-playbook -i inventory/hosts.yml playbooks/workstations.yml --limit localhost
+uv run ansible-playbook -i inventory/hosts.yml site.yml --limit localhost
 echo "✅ Workstation update complete."
 ```

--- a/.agents/skills/mac-workstation-update/SKILL.md
+++ b/.agents/skills/mac-workstation-update/SKILL.md
@@ -9,7 +9,7 @@ description: Runs the Ansible playbook to update the local macOS workstation con
 ### Prerequisites
 
 - Run this skill from the repository root so relative paths such as `inventory/hosts.yml` and `site.yml` resolve correctly.
-- Export `ANSIBLE_SUDO_PASS` in your environment before running this skill; the playbook reads it for `ansible_become_pass`.
+- Set `ANSIBLE_SUDO_PASS` as an inline environment variable on the `uv run ansible-playbook` invocation (see command below); the playbook reads it for `ansible_become_pass`.
 - Ensure `uv` is installed and the project dependencies needed for `ansible-playbook` are available.
 - This skill is intended only for macOS.
 
@@ -21,6 +21,6 @@ if [[ "$(uname)" != "Darwin" ]]; then
 fi
 
 echo "🚀 Updating local macOS workstation..."
-uv run ansible-playbook -i inventory/hosts.yml site.yml --limit localhost
+ANSIBLE_SUDO_PASS="$(read -rsp 'Sudo password: ' pw; echo "$pw")" uv run ansible-playbook -i inventory/hosts.yml site.yml --limit localhost
 echo "✅ Workstation update complete."
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -10,6 +10,5 @@ uv sync
 
 read -sp "Enter Sudo Password: " ANSIBLE_SUDO_PASSWORD
 echo ""
-export ANSIBLE_SUDO_PASS="$ANSIBLE_SUDO_PASSWORD"
 
-uv run ansible-playbook playbooks/workstations.yml
+ANSIBLE_SUDO_PASS="$ANSIBLE_SUDO_PASSWORD" uv run ansible-playbook site.yml


### PR DESCRIPTION
Updates the `bootstrap.sh` and the macOS workstation update skill to correctly reference `site.yml` instead of the old `playbooks/workstations.yml` path. It also implements a safer approach by passing `ANSIBLE_SUDO_PASS` inline rather than exporting it to the global environment.

---
*PR created automatically by Jules for task [8503670307656569029](https://jules.google.com/task/8503670307656569029) started by @davidasnider*