### PR TITLE
🛡️ Sentinel: [HIGH] Fix sensitive data leakage in logs

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The bootstrap.sh script exported the user's sudo password as the ANSIBLE_SUDO_PASS environment variable and did not clean it up after execution.
 **Learning:** Sensitive variables left in the environment can be accessed by child processes or linger in memory longer than necessary, increasing the attack surface.
 **Prevention:** Pass environment variables containing sensitive secrets (like passwords or tokens) inline to the commands that require them, rather than exporting them globally in the script. Note that this only limits the secret's scope to the shell session and that single command invocation — the command and its own child processes (e.g., Ansible modules doing an env lookup) can still read it. For stronger protection, prefer interactive prompts such as `--ask-become-pass` or a dedicated secret manager instead of passing secrets through the environment at all.
+
+## 2024-08-18 - Sensitive Data Leakage in Logs
+**Vulnerability:** The 1Password secure wrapper script (`op-secure`) logged the entire `op` command array (`$*`), including sensitive arguments like passwords and secret values, into a persistent log file (`~/.config/op/op-secure.log`).
+**Learning:** Command-line parameters passed to wrapper scripts are often blindly logged for debugging purposes. When interacting with secret managers or authentication tools, these parameters frequently contain sensitive data that should never touch the disk in plaintext.
+**Prevention:** Never log `$@` or `$*` when wrapping CLI tools that handle secrets. Always selectively log only safe parts of the command (e.g. just the subcommand, like `$1`) and omit the remaining arguments to prevent credential harvesting from log files.

--- a/roles/workstation/tasks/1password-security.yml
+++ b/roles/workstation/tasks/1password-security.yml
@@ -101,7 +101,7 @@
 
           while (( retry_count < MAX_RETRIES )); do
               if session_token=$(get_session_token); then
-                  log "INFO" "Executing op command: $*"
+                  log "INFO" "Executing op command: $1"
 
                   if timeout "$OP_TIMEOUT" op "$@" --session "$session_token"; then
                       log "INFO" "Command completed successfully"

--- a/roles/workstation/tasks/1password-security.yml
+++ b/roles/workstation/tasks/1password-security.yml
@@ -101,7 +101,23 @@
 
           while (( retry_count < MAX_RETRIES )); do
               if session_token=$(get_session_token); then
-                  log "INFO" "Executing op command: $1"
+                  # Log only the first bare token (the subcommand) so that
+                  # leading global flags, flags embedding values (e.g. --foo=bar),
+                  # and flag values are never written to the log file.
+                  local subcommand="" arg prev_was_flag=false
+                  for arg in "$@"; do
+                      if [[ "$arg" == -* ]]; then
+                          prev_was_flag=true
+                          continue
+                      fi
+                      if [[ "$prev_was_flag" == "true" ]]; then
+                          prev_was_flag=false
+                          continue
+                      fi
+                      subcommand="$arg"
+                      break
+                  done
+                  log "INFO" "Executing op command: ${subcommand:-unknown}"
 
                   if timeout "$OP_TIMEOUT" op "$@" --session "$session_token"; then
                       log "INFO" "Command completed successfully"


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `op-secure` wrapper script was logging the full command arguments (`$*`), including potential passwords, tokens, or secret values passed to the 1Password CLI, into a persistent plaintext log file (`~/.config/op/op-secure.log`).
🎯 **Impact:** Malicious actors or automated processes with read access to the log file could harvest credentials and sensitive secrets.
🔧 **Fix:** Modified the logging output to only log the main subcommand (`$1`) instead of all arguments. Added learning to `.jules/sentinel.md`.
✅ **Verification:** Verify by running an `op` command through the wrapper and checking that the log file only contains the command name, not its sensitive parameters. Run `make test`, `make test-lint` and `make test-syntax` to verify.

---
*PR created automatically by Jules for task [5700675770647076174](https://jules.google.com/task/5700675770647076174) started by @davidasnider*