### PR TITLE
⚡ Bolt: Consolidate apt cache update and package install

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - Ansible Execution Overhead
 **Learning:** Consolidating multiple similar Ansible module calls (like `community.general.git_config`) into a single task with a `loop` reduces task execution overhead (setup, plugin loading, and connection management).
 **Action:** Always look for sequential calls to the same module and group them using `loop`.
+
+## 2026-08-23 - Consolidate apt update and install
+**Learning:** In Ansible, `ansible.builtin.apt` can update the cache (`update_cache: true`) and install a package (`name`) in a single task, eliminating the overhead of running two separate tasks and establishing two separate connections. Note that combining `update_cache: true` with a package install does not require `cache_valid_time` if the cache was just updated with a new repository via `apt_repository`.
+**Action:** Always combine `update_cache` and package installation in a single `apt` module task when updating the cache right before an install.

--- a/roles/workstation/tasks/local-linux-packages.yml
+++ b/roles/workstation/tasks/local-linux-packages.yml
@@ -172,17 +172,11 @@
       retries: 3
       delay: 5
 
-    - name: Update apt cache
-      ansible.builtin.apt:
-        update_cache: true
-      become: true
-      retries: 3
-      delay: 5
-
-    - name: Install 1Password CLI
+    - name: Install 1Password CLI and update cache
       ansible.builtin.apt:
         name: 1password-cli
         state: present
+        update_cache: true
       become: true
       retries: 3
       delay: 5


### PR DESCRIPTION
💡 What: Combined the `Update apt cache` task into the `Install 1Password CLI` task by using `update_cache: true` within the `ansible.builtin.apt` installation task in `roles/workstation/tasks/local-linux-packages.yml`.
🎯 Why: To reduce playbook execution overhead. Ansible establishes separate connections and invokes the python interpreter for each task. Combining these two related `apt` operations avoids this unnecessary duplication.
📊 Impact: Playbook runs slightly faster and consumes fewer resources due to one less task execution on Linux systems.
🔬 Measurement: Verify by running `ansible-playbook --check -i inventory/hosts.yml site.yml` or checking task execution time when provisioning a Linux workstation.

This is a minor performance optimization following the Bolt principles.

---
*PR created automatically by Jules for task [2830696542852890940](https://jules.google.com/task/2830696542852890940) started by @davidasnider*