### PR TITLE
⚡ Bolt: Prevent redundant apt cache updates

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for docker
 
 - name: Install dependencies for Docker repository
+  # ⚡ Bolt: Added cache_valid_time to prevent redundant apt cache updates and speed up playbook execution
   ansible.builtin.apt:
     name:
       - ca-certificates
@@ -9,6 +10,7 @@
       - gnupg
     state: present
     update_cache: true
+    cache_valid_time: 86400
 
 - name: Create directory for Docker repository key
   ansible.builtin.file:

--- a/roles/home_assistant_remote/tasks/main.yml
+++ b/roles/home_assistant_remote/tasks/main.yml
@@ -2,6 +2,7 @@
 # tasks file for home_assistant_remote
 
 - name: Install Bluetooth stack and utilities
+  # ⚡ Bolt: Added cache_valid_time to prevent redundant apt cache updates and speed up playbook execution
   ansible.builtin.apt:
     name:
       - bluez
@@ -9,6 +10,7 @@
       - dbus
     state: present
     update_cache: true
+    cache_valid_time: 86400
 
 - name: Ensure Bluetooth service is running and enabled
   ansible.builtin.systemd:


### PR DESCRIPTION
💡 What: Added `cache_valid_time: 86400` (24 hours) to Ansible `apt` tasks in the `docker` and `home_assistant_remote` roles that use `update_cache: true`.

🎯 Why: In Ansible, when an `apt` task uses `update_cache: true` without a `cache_valid_time`, Ansible unconditionally runs an `apt-get update` every single time the playbook executes. This adds several seconds of unnecessary overhead to every playbook run.

📊 Impact: Reduces redundant network calls and speeds up overall playbook execution times by caching apt indices for 24 hours.

🔬 Measurement: Run the playbook twice. The first time, it should update the apt cache. The second time, the task should complete almost instantly without re-downloading the indices.

---
*PR created automatically by Jules for task [2964290856905062138](https://jules.google.com/task/2964290856905062138) started by @davidasnider*