### PR TITLE
🛡️ Sentinel: [HIGH] Fix Environment Variable Secret Leakage

### DIFF
--- a/.agents/skills/mac-workstation-update/SKILL.md
+++ b/.agents/skills/mac-workstation-update/SKILL.md
@@ -9,7 +9,7 @@ description: Runs the Ansible playbook to update the local macOS workstation con
 ### Prerequisites
 
 - Run this skill from the repository root so relative paths such as `inventory/hosts.yml` and `site.yml` resolve correctly.
-- Set `ANSIBLE_SUDO_PASS` as an inline environment variable on the `uv run ansible-playbook` invocation (see command below); the playbook reads it for `ansible_become_pass`.
+- You will be prompted for your sudo password when running the playbook because of the `--ask-become-pass` flag.
 - Ensure `uv` is installed and the project dependencies needed for `ansible-playbook` are available.
 - This skill is intended only for macOS.
 
@@ -21,6 +21,6 @@ if [[ "$(uname)" != "Darwin" ]]; then
 fi
 
 echo "🚀 Updating local macOS workstation..."
-ANSIBLE_SUDO_PASS="$(read -rsp 'Sudo password: ' pw; echo "$pw")" uv run ansible-playbook -i inventory/hosts.yml site.yml --limit localhost
+uv run ansible-playbook -i inventory/hosts.yml site.yml --limit localhost --ask-become-pass
 echo "✅ Workstation update complete."
 ```

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,10 +139,10 @@
         "filename": "README.md",
         "hashed_secret": "fefda504251b73d30a7cf3d047d241388a3c11b3",
         "is_verified": false,
-        "line_number": 537,
+        "line_number": 533,
         "is_secret": false
       }
     ]
   },
-  "generated_at": "2026-08-12T03:40:52Z"
+  "generated_at": "2026-08-25T03:13:54Z"
 }

--- a/README.md
+++ b/README.md
@@ -328,7 +328,6 @@ Required secrets are managed through a `~/.env` file with 1Password secret refer
 ```bash
 # Example .env file structure
 export GITHUB_TOKEN="op://vault/github-token/token"
-export ANSIBLE_SUDO_PASS="op://vault/sudo-password/password"
 ```
 
 ### Validation System
@@ -342,9 +341,7 @@ The zsh configuration checks for the presence of the .env file and verifies 1Pas
 ## Security Features
 
 ### Sudo Password Management
-- **Environment Variable**: Uses `ANSIBLE_SUDO_PASS` for automated privilege escalation
-- **Secure Storage**: Password stored in 1Password, referenced via secret URI
-- **Bootstrap Integration**: `bootstrap.sh` prompts for password when needed
+- **Bootstrap Integration**: `bootstrap.sh` prompts for password when needed using `--ask-become-pass`
 
 ### Secret Storage Strategy
 - **No Hardcoded Secrets**: All sensitive data referenced via 1Password URIs
@@ -408,7 +405,6 @@ opload
 
 # Verify required variables are loaded
 echo $GITHUB_TOKEN
-echo $ANSIBLE_SUDO_PASS
 ```
 
 ### GitHub Token Requirement
@@ -632,14 +628,8 @@ uv sync
 
 #### Sudo Password Issues
 ```bash
-# Ensure ANSIBLE_SUDO_PASS is set
-echo $ANSIBLE_SUDO_PASS
-
-# Load secrets if missing
-opload
-
-# Alternative: Set manually for testing
-export ANSIBLE_SUDO_PASS="your-sudo-pass"  # pragma: allowlist secret
+# Ensure you use --ask-become-pass when running ansible manually
+uv run ansible-playbook site.yml --ask-become-pass
 ```
 
 #### Permission Denied Errors

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,4 @@ source $HOME/.cargo/env
 
 uv sync
 
-read -sp "Enter Sudo Password: " ANSIBLE_SUDO_PASSWORD
-echo ""
-
-ANSIBLE_SUDO_PASS="$ANSIBLE_SUDO_PASSWORD" uv run ansible-playbook site.yml
+uv run ansible-playbook site.yml --ask-become-pass

--- a/playbooks/workstations.yml
+++ b/playbooks/workstations.yml
@@ -2,8 +2,6 @@
 - name: Setup Workstations
   hosts: workstations
   gather_facts: true
-  vars:
-    ansible_become_pass: "{{ lookup('ansible.builtin.env', 'ANSIBLE_SUDO_PASS') }}"
 
   roles:
     - workstation


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Environment Variable Secret Leakage

**Severity:** HIGH
**Vulnerability:** The `ANSIBLE_SUDO_PASS` environment variable was used to manage the sudo password across `bootstrap.sh`, Agent skills, and playbook definitions.
**Impact:** Environment variables are highly visible to child processes, system debugging tools, crash dumps, and tools like `ps` (via `/proc/<pid>/environ`). Storing plaintext passwords in them is a severe anti-pattern that can lead to credential leakage.
**Fix:** Removed all dependencies on `ANSIBLE_SUDO_PASS`. Substituted its usage with Ansible's native interactive prompt: `--ask-become-pass`. This ensures the password is read securely via a TTY and never hits the process environment or disk.
**Verification:** Validated that `bootstrap.sh` and the agent skill use the `-K` / `--ask-become-pass` flags correctly. Tested with `make test`, updated `.secrets.baseline`, and ran pre-commit checks. All changes have passed 3 rounds of code review.

---
*PR created automatically by Jules for task [11572596085418756297](https://jules.google.com/task/11572596085418756297) started by @davidasnider*