### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Environment Variable Leakage in bootstrap.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The 1Password secure wrapper script (`op-secure`) logged the entire `op` command array (`$*`), including sensitive arguments like passwords and secret values, into a persistent log file (`~/.config/op/op-secure.log`).
 **Learning:** Command-line parameters passed to wrapper scripts are often blindly logged for debugging purposes. When interacting with secret managers or authentication tools, these parameters frequently contain sensitive data that should never touch the disk in plaintext.
 **Prevention:** Never log `$@` or `$*` when wrapping CLI tools that handle secrets. Always selectively log only safe parts of the command (e.g. just the subcommand, like `$1`) and omit the remaining arguments to prevent credential harvesting from log files.
+
+## 2024-10-17 - Environment Variable Leakage in Bootstrap
+**Vulnerability:** The `bootstrap.sh` script previously read the sudo password and passed it via the `ANSIBLE_SUDO_PASS` environment variable, exposing it to child processes and memory.
+**Learning:** Hardcoding or passing secrets through environment variables in scripts introduces an unneeded attack surface.
+**Prevention:** Native interactive tools (such as `--ask-become-pass` for Ansible) should be used instead of manual prompt loops combined with environment variables for secret ingestion.

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,4 @@ source $HOME/.cargo/env
 
 uv sync
 
-read -sp "Enter Sudo Password: " ANSIBLE_SUDO_PASSWORD
-echo ""
-
-ANSIBLE_SUDO_PASS="$ANSIBLE_SUDO_PASSWORD" uv run ansible-playbook site.yml
+uv run ansible-playbook site.yml --ask-become-pass


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `bootstrap.sh` script prompted for the user's sudo password using `read -sp` and injected it into a global shell variable `ANSIBLE_SUDO_PASS`, passing it downstream to `uv run ansible-playbook`.
🎯 **Impact**: Environment variables injected in scripts are exposed to memory, crash dumps, loggers (if not sanitized), and potentially child processes spawned by the command. This is an unnecessary risk for a highly sensitive credential like a sudo password.
🔧 **Fix**: Refactored the `ansible-playbook` invocation to utilize Ansible's native `--ask-become-pass` flag. This delegates the secure prompt and memory management directly to Ansible, bypassing the shell environment variable completely. Added the finding to the Sentinel journal for future reference.
✅ **Verification**: Run `./bootstrap.sh`. The script should now safely prompt for the sudo password using Ansible's native handler rather than the bash prompt. Run `make test` to ensure there are no syntax or linting regressions.

---
*PR created automatically by Jules for task [17014377291386404534](https://jules.google.com/task/17014377291386404534) started by @davidasnider*