### PR TITLE
⚡ Bolt: Add cache_valid_time to prevent redundant apt-get updates

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # tasks file for docker
 
+# ⚡ Bolt: Added cache_valid_time to prevent redundant apt-get update executions on idempotent runs
 - name: Install dependencies for Docker repository
   ansible.builtin.apt:
     name:
@@ -9,6 +10,7 @@
       - gnupg
     state: present
     update_cache: true
+    cache_valid_time: 86400
 
 - name: Create directory for Docker repository key
   ansible.builtin.file:

--- a/roles/home_assistant_remote/tasks/main.yml
+++ b/roles/home_assistant_remote/tasks/main.yml
@@ -1,6 +1,7 @@
 ---
 # tasks file for home_assistant_remote
 
+# ⚡ Bolt: Added cache_valid_time to prevent redundant apt-get update executions on idempotent runs
 - name: Install Bluetooth stack and utilities
   ansible.builtin.apt:
     name:
@@ -9,6 +10,7 @@
       - dbus
     state: present
     update_cache: true
+    cache_valid_time: 86400
 
 - name: Ensure Bluetooth service is running and enabled
   ansible.builtin.systemd:


### PR DESCRIPTION
💡 What: Added `cache_valid_time: 86400` to Ansible apt tasks running `update_cache: true`, except for the task immediately following a repository addition.

🎯 Why: Running `apt-get update` unconditionally via Ansible's `update_cache: true` creates a significant and slow bottleneck on every idempotent playbook run. By setting a cache validity window, Ansible skips the update if the cache is reasonably fresh, while properly ensuring newly added repositories still trigger an immediate update.

📊 Impact: Significantly speeds up playbook execution times for all Linux setups (Workstations, Raspberry Pis, Docker, HA) on subsequent runs by eliminating slow, redundant apt cache refreshes.

🔬 Measurement: Run `ansible-playbook site.yml` twice. The first run will execute `apt-get update`. The second run will execute significantly faster as the `apt` module will identify the cache is still valid and skip the update overhead.

---
*PR created automatically by Jules for task [17592565155391422654](https://jules.google.com/task/17592565155391422654) started by @davidasnider*