### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix environment variable leakage for sudo password

### DIFF
--- a/.agents/skills/mac-workstation-update/SKILL.md
+++ b/.agents/skills/mac-workstation-update/SKILL.md
@@ -9,7 +9,7 @@ description: Runs the Ansible playbook to update the local macOS workstation con
 ### Prerequisites
 
 - Run this skill from the repository root so relative paths such as `inventory/hosts.yml` and `site.yml` resolve correctly.
-- Set `ANSIBLE_SUDO_PASS` as an inline environment variable on the `uv run ansible-playbook` invocation (see command below); the playbook reads it for `ansible_become_pass`.
+- The script uses `--ask-become-pass` to securely prompt for the sudo password.
 - Ensure `uv` is installed and the project dependencies needed for `ansible-playbook` are available.
 - This skill is intended only for macOS.
 
@@ -21,6 +21,6 @@ if [[ "$(uname)" != "Darwin" ]]; then
 fi
 
 echo "🚀 Updating local macOS workstation..."
-ANSIBLE_SUDO_PASS="$(read -rsp 'Sudo password: ' pw; echo "$pw")" uv run ansible-playbook -i inventory/hosts.yml site.yml --limit localhost
+uv run ansible-playbook --ask-become-pass -i inventory/hosts.yml site.yml --limit localhost
 echo "✅ Workstation update complete."
 ```

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -8,7 +8,5 @@ source $HOME/.cargo/env
 
 uv sync
 
-read -sp "Enter Sudo Password: " ANSIBLE_SUDO_PASSWORD
-echo ""
 
-ANSIBLE_SUDO_PASS="$ANSIBLE_SUDO_PASSWORD" uv run ansible-playbook site.yml
+uv run ansible-playbook --ask-become-pass site.yml

--- a/playbooks/workstations.yml
+++ b/playbooks/workstations.yml
@@ -2,8 +2,6 @@
 - name: Setup Workstations
   hosts: workstations
   gather_facts: true
-  vars:
-    ansible_become_pass: "{{ lookup('ansible.builtin.env', 'ANSIBLE_SUDO_PASS') }}"
 
   roles:
     - workstation


### PR DESCRIPTION
🛡️ **Sentinel Security Fix**

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The automation scripts (`bootstrap.sh` and the macOS `SKILL.md`) previously loaded the user's sudo password into the `ANSIBLE_SUDO_PASS` environment variable and passed it to the `ansible-playbook` invocation inline. Additionally, `playbooks/workstations.yml` read the environment variable directly.
🎯 **Impact:** Leaving highly sensitive secrets (such as the sudo password) in environment variables is insecure. They can leak through bash history, process lists (`ps`), crash dumps, child process environment inspection (`/proc/<pid>/environ`), or debugging output.
🔧 **Fix:** 
1. Replaced the custom password prompt and environment variable workaround with Ansible's native `--ask-become-pass` (`-K`) flag in both `bootstrap.sh` and `.agents/skills/mac-workstation-update/SKILL.md`.
2. Removed the explicit insecure environment variable lookup `ansible_become_pass: "{{ lookup('ansible.builtin.env', 'ANSIBLE_SUDO_PASS') }}"` from `playbooks/workstations.yml`.
✅ **Verification:** Verified by executing `make test` locally to ensure Ansible syntax parsing, yaml, and secrets-linting completed successfully.

---
*PR created automatically by Jules for task [6098101106552541559](https://jules.google.com/task/6098101106552541559) started by @davidasnider*